### PR TITLE
Add calendar popup to Days From Date calculator

### DIFF
--- a/public/js/days-from-date.js
+++ b/public/js/days-from-date.js
@@ -13,6 +13,11 @@
     const d = new Date(y, m - 1, da);
     return d && d.getFullYear() === y && d.getMonth() === m - 1 && d.getDate() === da ? d : null;
   }
+  function formatISODate(d) {
+    const mm = String(d.getMonth() + 1).padStart(2, "0");
+    const dd = String(d.getDate()).padStart(2, "0");
+    return d.getFullYear() + "-" + mm + "-" + dd;
+  }
   function daysBetween(a, b) {
     const MS = 86400000;
     return Math.round((stripTime(b) - stripTime(a)) / MS);
@@ -20,11 +25,49 @@
   function plural(n) { return Math.abs(n) === 1 ? "" : "s"; }
   function card(html) { return '<section class="card" style="margin-top:16px;">' + html + "</section>"; }
 
+  function setupCalendarPickers() {
+    const fields = document.querySelectorAll(".date-input");
+    fields.forEach((field) => {
+      const textInput = field.querySelector('[data-role="date-text"]');
+      const pickerInput = field.querySelector('[data-role="date-picker"]');
+      const trigger = field.querySelector(".date-trigger");
+      if (!textInput || !pickerInput || !trigger) return;
+
+      const syncPicker = () => {
+        const parsed = parseDate(textInput.value.trim());
+        pickerInput.value = parsed ? formatISODate(parsed) : "";
+      };
+
+      syncPicker();
+
+      trigger.addEventListener("click", () => {
+        syncPicker();
+        if (typeof pickerInput.showPicker === "function") {
+          pickerInput.showPicker();
+        } else {
+          pickerInput.focus();
+          pickerInput.click();
+        }
+      });
+
+      pickerInput.addEventListener("change", () => {
+        if (pickerInput.value) {
+          textInput.value = pickerInput.value;
+          textInput.dispatchEvent(new Event("input", { bubbles: true }));
+        }
+      });
+
+      textInput.addEventListener("input", syncPicker);
+    });
+  }
+
   const dateEl = document.getElementById("date");
   const compareEl = document.getElementById("compare");
   const calcBtn = document.getElementById("calc");
   const clearBtn = document.getElementById("clear");
   const out = document.getElementById("result");
+
+  setupCalendarPickers();
   if (!dateEl || !calcBtn || !out) return;
 
   calcBtn.addEventListener("click", () => {
@@ -44,6 +87,8 @@
 
   clearBtn && clearBtn.addEventListener("click", () => {
     dateEl.value = ""; compareEl.value = ""; out.innerHTML = "";
+    dateEl.dispatchEvent(new Event("input", { bubbles: true }));
+    compareEl.dispatchEvent(new Event("input", { bubbles: true }));
     dateEl.focus();
   });
 })();

--- a/src/pages/calculators/days-from-date.astro
+++ b/src/pages/calculators/days-from-date.astro
@@ -14,16 +14,50 @@ const description = "Calculate days between today and a specific date, or betwee
   <section class="card" style="margin-top:18px;">
     <form id="dfd-form">
       <label for="date">Date</label>
-      <input id="date" name="date" type="text" inputmode="numeric" placeholder="YYYY-MM-DD or MM/DD/YYYY" />
+      <div class="date-input">
+        <input
+          id="date"
+          name="date"
+          type="text"
+          inputmode="numeric"
+          placeholder="YYYY-MM-DD or MM/DD/YYYY"
+          data-role="date-text"
+        />
+        <button class="date-trigger" type="button" aria-label="Open calendar for date">
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path
+              d="M7 2a1 1 0 0 1 1 1v1h8V3a1 1 0 1 1 2 0v1h1.5A2.5 2.5 0 0 1 22 6.5v13A2.5 2.5 0 0 1 19.5 22h-15A2.5 2.5 0 0 1 2 19.5v-13A2.5 2.5 0 0 1 4.5 4H6V3a1 1 0 0 1 1-1Zm0 4H4.5a.5.5 0 0 0-.5.5V8h16V6.5a.5.5 0 0 0-.5-.5H17v1a1 1 0 0 1-2 0V6H8v1a1 1 0 0 1-2 0V6Zm13 4H4v9.5a.5.5 0 0 0 .5.5h15a.5.5 0 0 0 .5-.5V10Z"
+            />
+          </svg>
+        </button>
+        <input type="date" class="date-picker" data-role="date-picker" aria-hidden="true" tabindex="-1" />
+      </div>
 
       <label for="compare">Compare To (optional)</label>
-      <input id="compare" name="compare" type="text" inputmode="numeric" placeholder="Leave empty to use today" />
+      <div class="date-input">
+        <input
+          id="compare"
+          name="compare"
+          type="text"
+          inputmode="numeric"
+          placeholder="Leave empty to use today"
+          data-role="date-text"
+        />
+        <button class="date-trigger" type="button" aria-label="Open calendar for comparison date">
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path
+              d="M7 2a1 1 0 0 1 1 1v1h8V3a1 1 0 1 1 2 0v1h1.5A2.5 2.5 0 0 1 22 6.5v13A2.5 2.5 0 0 1 19.5 22h-15A2.5 2.5 0 0 1 2 19.5v-13A2.5 2.5 0 0 1 4.5 4H6V3a1 1 0 0 1 1-1Zm0 4H4.5a.5.5 0 0 0-.5.5V8h16V6.5a.5.5 0 0 0-.5-.5H17v1a1 1 0 0 1-2 0V6H8v1a1 1 0 0 1-2 0V6Zm13 4H4v9.5a.5.5 0 0 0 .5.5h15a.5.5 0 0 0 .5-.5V10Z"
+            />
+          </svg>
+        </button>
+        <input type="date" class="date-picker" data-role="date-picker" aria-hidden="true" tabindex="-1" />
+      </div>
 
       <div style="margin-top:14px; display:flex; gap:10px;">
         <button class="btn" type="button" id="calc">Calculate</button>
         <button class="btn" type="button" id="clear">Clear</button>
       </div>
-      <p class="helper" style="margin-top:10px;">Tip: Click inside the inputs and use your device’s date picker if available.</p>
+      <p class="helper" style="margin-top:10px;">Tip: Use the calendar buttons or type a date manually.</p>
     </form>
   </section>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -96,6 +96,35 @@ input, select {
   width: 100%; padding: 10px 12px; border-radius: 10px;
   border: 1px solid var(--border); background:#0d1325; color: var(--text);
 }
+.date-input { position: relative; }
+.date-input input[data-role="date-text"] { padding-right: 44px; }
+.date-trigger {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: var(--muted);
+  padding: 6px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: color .15s ease, background .15s ease;
+}
+.date-trigger:hover,
+.date-trigger:focus-visible {
+  color: var(--text);
+  background: rgba(78, 140, 255, 0.12);
+  outline: none;
+}
+.date-trigger svg { width: 18px; height: 18px; display: block; fill: currentColor; }
+.date-picker {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 0;
+  height: 0;
+}
 .helper { font-size: 13px; color: var(--muted); }
 
 /* Ad placeholder (keep but subtle) */


### PR DESCRIPTION
## Summary
- add calendar trigger buttons beside the date inputs on the Days From (or Until) a Date calculator
- style the new calendar controls and hide the backing date inputs
- update the calculator script to open the browser date picker and sync values between text and calendar inputs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c86354003083238962b968874a3f6c