### PR TITLE
Add age calculator page

### DIFF
--- a/public/js/age-calculator.js
+++ b/public/js/age-calculator.js
@@ -1,0 +1,199 @@
+(function () {
+  function stripTime(d) {
+    return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  }
+  function parseDate(input) {
+    if (!input) return null;
+    const iso = /^(\d{4})-(\d{2})-(\d{2})$/;
+    const us = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/;
+    let y, m, da;
+    if (iso.test(input)) {
+      const m1 = input.match(iso);
+      y = +m1[1];
+      m = +m1[2];
+      da = +m1[3];
+    } else if (us.test(input)) {
+      const m2 = input.match(us);
+      m = +m2[1];
+      da = +m2[2];
+      y = +m2[3];
+    } else return null;
+    const d = new Date(y, m - 1, da);
+    return d &&
+      d.getFullYear() === y &&
+      d.getMonth() === m - 1 &&
+      d.getDate() === da
+      ? d
+      : null;
+  }
+  function formatISODate(d) {
+    const mm = String(d.getMonth() + 1).padStart(2, "0");
+    const dd = String(d.getDate()).padStart(2, "0");
+    return d.getFullYear() + "-" + mm + "-" + dd;
+  }
+  function plural(n) {
+    return Math.abs(n) === 1 ? "" : "s";
+  }
+  function card(html) {
+    return (
+      '<section class="card" style="margin-top:16px;">' + html + "</section>"
+    );
+  }
+  function daysInMonth(year, month) {
+    return new Date(year, month + 1, 0).getDate();
+  }
+  function addMonthsClamped(date, count, anchorDay) {
+    const y = date.getFullYear();
+    const m = date.getMonth() + count;
+    const targetYear = y + Math.floor(m / 12);
+    const targetMonth = ((m % 12) + 12) % 12;
+    const day = anchorDay !== undefined ? anchorDay : date.getDate();
+    const dim = daysInMonth(targetYear, targetMonth);
+    return new Date(targetYear, targetMonth, Math.min(day, dim));
+  }
+  function diffParts(start, end) {
+    start = stripTime(start);
+    end = stripTime(end);
+    if (start > end) return null;
+    let years = end.getFullYear() - start.getFullYear();
+    let anniversary = addMonthsClamped(start, years * 12, start.getDate());
+    if (anniversary > end) {
+      years -= 1;
+      anniversary = addMonthsClamped(start, years * 12, start.getDate());
+    }
+    let months = 0;
+    let cursor = anniversary;
+    while (true) {
+      const next = addMonthsClamped(cursor, 1, start.getDate());
+      if (next > end) break;
+      cursor = next;
+      months += 1;
+    }
+    const days = Math.round((end - cursor) / 86400000);
+    return { years, months, days };
+  }
+  function nextBirthday(birth, from) {
+    const anchorDay = birth.getDate();
+    let candidate = new Date(from.getFullYear(), birth.getMonth(), 1);
+    const dim = daysInMonth(candidate.getFullYear(), candidate.getMonth());
+    candidate.setDate(Math.min(anchorDay, dim));
+    if (candidate <= from) {
+      const year = from.getFullYear() + 1;
+      const dimNext = daysInMonth(year, birth.getMonth());
+      candidate = new Date(
+        year,
+        birth.getMonth(),
+        Math.min(anchorDay, dimNext),
+      );
+    }
+    return candidate;
+  }
+  function setupCalendarPickers() {
+    const fields = document.querySelectorAll(".date-input");
+    fields.forEach((field) => {
+      const textInput = field.querySelector('[data-role="date-text"]');
+      const pickerInput = field.querySelector('[data-role="date-picker"]');
+      const trigger = field.querySelector(".date-trigger");
+      if (!textInput || !pickerInput || !trigger) return;
+
+      const syncPicker = () => {
+        const parsed = parseDate(textInput.value.trim());
+        pickerInput.value = parsed ? formatISODate(parsed) : "";
+      };
+
+      syncPicker();
+
+      trigger.addEventListener("click", () => {
+        syncPicker();
+        if (typeof pickerInput.showPicker === "function") {
+          pickerInput.showPicker();
+        } else {
+          pickerInput.focus();
+          pickerInput.click();
+        }
+      });
+
+      pickerInput.addEventListener("change", () => {
+        if (pickerInput.value) {
+          textInput.value = pickerInput.value;
+          textInput.dispatchEvent(new Event("input", { bubbles: true }));
+        }
+      });
+
+      textInput.addEventListener("input", syncPicker);
+    });
+  }
+
+  const birthInput = document.getElementById("birthdate");
+  const calcBtn = document.getElementById("age-calc");
+  const clearBtn = document.getElementById("age-clear");
+  const out = document.getElementById("age-result");
+
+  setupCalendarPickers();
+  if (!birthInput || !calcBtn || !out) return;
+
+  function render() {
+    const birth = parseDate(birthInput.value.trim());
+    const today = stripTime(new Date());
+    if (!birth) {
+      out.innerHTML = card("<p>Please enter a valid birthdate.</p>");
+      return;
+    }
+    if (birth > today) {
+      out.innerHTML = card("<p>Birthdate can't be in the future.</p>");
+      return;
+    }
+    const parts = diffParts(birth, today);
+    if (!parts) {
+      out.innerHTML = card("<p>Please enter a valid birthdate.</p>");
+      return;
+    }
+    const totalDays = Math.round((today - stripTime(birth)) / 86400000);
+    const next = nextBirthday(birth, today);
+    const untilNext = Math.round((stripTime(next) - today) / 86400000);
+    const html =
+      "<h3>Result</h3>" +
+      "<p>You are <strong>" +
+      parts.years +
+      "</strong> year" +
+      plural(parts.years) +
+      ", <strong>" +
+      parts.months +
+      "</strong> month" +
+      plural(parts.months) +
+      ", and <strong>" +
+      parts.days +
+      "</strong> day" +
+      plural(parts.days) +
+      " old.</p>" +
+      '<p class="helper">That is about ' +
+      totalDays.toLocaleString() +
+      " day" +
+      plural(totalDays) +
+      " alive.</p>" +
+      '<p class="helper">Next birthday: ' +
+      next.toDateString() +
+      " (in " +
+      untilNext +
+      " day" +
+      plural(untilNext) +
+      ").</p>";
+    out.innerHTML = card(html);
+  }
+
+  calcBtn.addEventListener("click", render);
+  birthInput.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      render();
+    }
+  });
+
+  clearBtn &&
+    clearBtn.addEventListener("click", () => {
+      birthInput.value = "";
+      out.innerHTML = "";
+      birthInput.dispatchEvent(new Event("input", { bubbles: true }));
+      birthInput.focus();
+    });
+})();

--- a/public/js/date-utils.js
+++ b/public/js/date-utils.js
@@ -1,0 +1,114 @@
+(function () {
+  if (typeof window === "undefined") return;
+
+  const MS_IN_DAY = 86400000;
+  const isoPattern = /^(\d{4})-(\d{2})-(\d{2})$/;
+  const usPattern = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/;
+
+  function stripTime(date) {
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  }
+
+  function parseDate(input) {
+    if (!input) return null;
+    const value = input.trim();
+    let year;
+    let month;
+    let day;
+
+    if (isoPattern.test(value)) {
+      const match = value.match(isoPattern);
+      if (!match) return null;
+      year = Number(match[1]);
+      month = Number(match[2]);
+      day = Number(match[3]);
+    } else if (usPattern.test(value)) {
+      const match = value.match(usPattern);
+      if (!match) return null;
+      month = Number(match[1]);
+      day = Number(match[2]);
+      year = Number(match[3]);
+    } else {
+      return null;
+    }
+
+    const result = new Date(year, month - 1, day);
+    if (
+      !result ||
+      result.getFullYear() !== year ||
+      result.getMonth() !== month - 1 ||
+      result.getDate() !== day
+    ) {
+      return null;
+    }
+    return result;
+  }
+
+  function formatISODate(date) {
+    const mm = String(date.getMonth() + 1).padStart(2, "0");
+    const dd = String(date.getDate()).padStart(2, "0");
+    return `${date.getFullYear()}-${mm}-${dd}`;
+  }
+
+  function plural(value) {
+    return Math.abs(Number(value)) === 1 ? "" : "s";
+  }
+
+  function setupCalendarPickers(root = document) {
+    const scope = root && typeof root.querySelectorAll === "function" ? root : document;
+    const fields = scope.querySelectorAll(".date-input");
+    fields.forEach((field) => {
+      if (field.dataset.datePickerReady === "true") return;
+      field.dataset.datePickerReady = "true";
+
+      const textInput = field.querySelector('[data-role="date-text"]');
+      const pickerInput = field.querySelector('[data-role="date-picker"]');
+      const trigger = field.querySelector(".date-trigger");
+      if (!textInput) return;
+
+      const syncPicker = () => {
+        if (!pickerInput) return;
+        const parsed = parseDate(textInput.value.trim());
+        pickerInput.value = parsed ? formatISODate(parsed) : "";
+      };
+
+      if (pickerInput) {
+        syncPicker();
+        pickerInput.addEventListener("change", () => {
+          textInput.value = pickerInput.value ? pickerInput.value : "";
+          textInput.dispatchEvent(new Event("input", { bubbles: true }));
+        });
+      }
+
+      if (trigger && pickerInput) {
+        trigger.addEventListener("click", () => {
+          syncPicker();
+          if (typeof pickerInput.showPicker === "function") {
+            pickerInput.showPicker();
+          } else {
+            pickerInput.focus();
+            pickerInput.click();
+          }
+        });
+      }
+
+      textInput.addEventListener("input", syncPicker);
+
+      const form = field.closest("form");
+      if (form) {
+        form.addEventListener("reset", () => {
+          window.requestAnimationFrame(syncPicker);
+        });
+      }
+    });
+  }
+
+  window.CalcDate = Object.assign(window.CalcDate || {}, {
+    MS_IN_DAY,
+    formatISODate,
+    parseDate,
+    plural,
+    setupCalendarPickers,
+    stripTime,
+  });
+})();

--- a/public/js/days-from-date.js
+++ b/public/js/days-from-date.js
@@ -1,94 +1,80 @@
 (function () {
-  function stripTime(d) { return new Date(d.getFullYear(), d.getMonth(), d.getDate()); }
-  function parseDate(input) {
-    if (!input) return null;
-    const iso = /^(\d{4})-(\d{2})-(\d{2})$/;
-    const us  = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/;
-    let y, m, da;
-    if (iso.test(input)) {
-      const m1 = input.match(iso); y = +m1[1]; m = +m1[2]; da = +m1[3];
-    } else if (us.test(input)) {
-      const m2 = input.match(us); m = +m2[1]; da = +m2[2]; y = +m2[3];
-    } else return null;
-    const d = new Date(y, m - 1, da);
-    return d && d.getFullYear() === y && d.getMonth() === m - 1 && d.getDate() === da ? d : null;
-  }
-  function formatISODate(d) {
-    const mm = String(d.getMonth() + 1).padStart(2, "0");
-    const dd = String(d.getDate()).padStart(2, "0");
-    return d.getFullYear() + "-" + mm + "-" + dd;
-  }
-  function daysBetween(a, b) {
-    const MS = 86400000;
-    return Math.round((stripTime(b) - stripTime(a)) / MS);
-  }
-  function plural(n) { return Math.abs(n) === 1 ? "" : "s"; }
-  function card(html) { return '<section class="card" style="margin-top:16px;">' + html + "</section>"; }
+  if (typeof window === "undefined" || !window.CalcDate) return;
 
-  function setupCalendarPickers() {
-    const fields = document.querySelectorAll(".date-input");
-    fields.forEach((field) => {
-      const textInput = field.querySelector('[data-role="date-text"]');
-      const pickerInput = field.querySelector('[data-role="date-picker"]');
-      const trigger = field.querySelector(".date-trigger");
-      if (!textInput || !pickerInput || !trigger) return;
+  const {
+    MS_IN_DAY,
+    parseDate,
+    plural,
+    setupCalendarPickers,
+    stripTime,
+  } = window.CalcDate;
 
-      const syncPicker = () => {
-        const parsed = parseDate(textInput.value.trim());
-        pickerInput.value = parsed ? formatISODate(parsed) : "";
-      };
+  const form = document.getElementById("dfd-form");
+  const dateInput = document.getElementById("date");
+  const compareInput = document.getElementById("compare");
+  const output = document.getElementById("result");
+  if (!form || !dateInput || !compareInput || !output) return;
 
-      syncPicker();
+  setupCalendarPickers(form);
 
-      trigger.addEventListener("click", () => {
-        syncPicker();
-        if (typeof pickerInput.showPicker === "function") {
-          pickerInput.showPicker();
-        } else {
-          pickerInput.focus();
-          pickerInput.click();
-        }
-      });
+  const dateFormatter =
+    typeof Intl !== "undefined" && typeof Intl.DateTimeFormat === "function"
+      ? new Intl.DateTimeFormat(undefined, { dateStyle: "long" })
+      : null;
 
-      pickerInput.addEventListener("change", () => {
-        if (pickerInput.value) {
-          textInput.value = pickerInput.value;
-          textInput.dispatchEvent(new Event("input", { bubbles: true }));
-        }
-      });
+  const formatFullDate = (date) =>
+    dateFormatter ? dateFormatter.format(date) : date.toDateString();
 
-      textInput.addEventListener("input", syncPicker);
-    });
-  }
+  const card = (html) => `<section class="card" style="margin-top:16px;">${html}</section>`;
 
-  const dateEl = document.getElementById("date");
-  const compareEl = document.getElementById("compare");
-  const calcBtn = document.getElementById("calc");
-  const clearBtn = document.getElementById("clear");
-  const out = document.getElementById("result");
+  const daysBetween = (start, end) => {
+    return Math.round((stripTime(end) - stripTime(start)) / MS_IN_DAY);
+  };
 
-  setupCalendarPickers();
-  if (!dateEl || !calcBtn || !out) return;
+  const render = () => {
+    const targetRaw = dateInput.value.trim();
+    const compareRaw = compareInput.value.trim();
+    const target = parseDate(targetRaw);
+    const comparison = compareRaw ? parseDate(compareRaw) : stripTime(new Date());
 
-  calcBtn.addEventListener("click", () => {
-    const date = parseDate(dateEl.value.trim());
-    const comp = compareEl.value.trim() ? parseDate(compareEl.value.trim()) : stripTime(new Date());
-    if (!date || !comp) {
-      out.innerHTML = card('<p>Please enter valid date(s).</p>');
+    if (!target || !comparison) {
+      output.innerHTML = card("<p>Please enter valid date(s).</p>");
       return;
     }
-    const diff = daysBetween(comp, date);
-    let text;
-    if (diff === 0) text = "Your date is <strong>today</strong>.";
-    else if (diff > 0) text = "Your date is in <strong>" + diff + "</strong> day" + plural(diff) + ".";
-    else text = "Your date was <strong>" + Math.abs(diff) + "</strong> day" + plural(diff) + " ago.";
-    out.innerHTML = card('<h3>Result</h3><p>' + text + " <span class=\"helper\">(Compared to " + comp.toDateString() + ".)</span></p>");
+
+    const normalizedTarget = stripTime(target);
+    const normalizedComparison = stripTime(comparison);
+    const diff = daysBetween(normalizedComparison, normalizedTarget);
+
+    let summary;
+    if (diff === 0) {
+      summary = "Your date is <strong>today</strong>.";
+    } else if (diff > 0) {
+      summary = `Your date is in <strong>${diff.toLocaleString()}</strong> day${plural(diff)}.`;
+    } else {
+      const abs = Math.abs(diff);
+      summary = `Your date was <strong>${abs.toLocaleString()}</strong> day${plural(abs)} ago.`;
+    }
+
+    const html =
+      `<h3>Result</h3>` +
+      `<p>${summary}</p>` +
+      `<p class="helper">Compared to ${formatFullDate(normalizedComparison)}.</p>`;
+
+    output.innerHTML = card(html);
+  };
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    render();
   });
 
-  clearBtn && clearBtn.addEventListener("click", () => {
-    dateEl.value = ""; compareEl.value = ""; out.innerHTML = "";
-    dateEl.dispatchEvent(new Event("input", { bubbles: true }));
-    compareEl.dispatchEvent(new Event("input", { bubbles: true }));
-    dateEl.focus();
+  form.addEventListener("reset", () => {
+    window.requestAnimationFrame(() => {
+      output.innerHTML = "";
+      dateInput.dispatchEvent(new Event("input", { bubbles: true }));
+      compareInput.dispatchEvent(new Event("input", { bubbles: true }));
+      dateInput.focus();
+    });
   });
 })();

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -30,6 +30,7 @@ const url = new URL(pathname, Astro.site ?? "http://localhost:4321");
         <a class="brand" href="/">CalcNest</a>
         <nav class="nav" aria-label="Main">
           <a href="/calculators/days-from-date">Days From Date</a>
+          <a href="/calculators/age-calculator">Age</a>
           <a href="/calculators/days-until-birthday">Birthday</a>
           <a href="/calculators/holiday-countdown">Holidays</a>
         </nav>

--- a/src/pages/calculators/age-calculator.astro
+++ b/src/pages/calculators/age-calculator.astro
@@ -1,0 +1,49 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Age Calculator";
+const description = "Enter a birthdate and instantly get age in years, months, and days.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/age-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">Type your birthdate. We'll break down your age by years, months, and days.</p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="age-form">
+      <label for="birthdate">Birthdate</label>
+      <div class="date-input">
+        <input
+          id="birthdate"
+          name="birthdate"
+          type="text"
+          inputmode="numeric"
+          placeholder="YYYY-MM-DD or MM/DD/YYYY"
+          data-role="date-text"
+        />
+        <button class="date-trigger" type="button" aria-label="Open calendar for birthdate">
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path
+              d="M7 2a1 1 0 0 1 1 1v1h8V3a1 1 0 1 1 2 0v1h1.5A2.5 2.5 0 0 1 22 6.5v13A2.5 2.5 0 0 1 19.5 22h-15A2.5 2.5 0 0 1 2 19.5v-13A2.5 2.5 0 0 1 4.5 4H6V3a1 1 0 0 1 1-1Zm0 4H4.5a.5.5 0 0 0-.5.5V8h16V6.5a.5.5 0 0 0-.5-.5H17v1a1 1 0 0 1-2 0V6H8v1a1 1 0 0 1-2 0V6Zm13 4H4v9.5a.5.5 0 0 0 .5.5h15a.5.5 0 0 0 .5-.5V10Z"
+            />
+          </svg>
+        </button>
+        <input type="date" class="date-picker" data-role="date-picker" aria-hidden="true" tabindex="-1" />
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px;">
+        <button class="btn" type="button" id="age-calc">Calculate Age</button>
+        <button class="btn" type="button" id="age-clear">Clear</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">Tip: Use the calendar button or type a date manually.</p>
+    </form>
+  </section>
+
+  <section id="age-result" style="margin-top:16px;"></section>
+
+  <AdSlot id="age-inline-1" />
+  <script defer src="/js/age-calculator.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/age-calculator.astro
+++ b/src/pages/calculators/age-calculator.astro
@@ -21,6 +21,7 @@ const description = "Enter a birthdate and instantly get age in years, months, a
           name="birthdate"
           type="text"
           inputmode="numeric"
+          autocomplete="bday"
           placeholder="YYYY-MM-DD or MM/DD/YYYY"
           data-role="date-text"
         />
@@ -35,15 +36,16 @@ const description = "Enter a birthdate and instantly get age in years, months, a
       </div>
 
       <div style="margin-top:14px; display:flex; gap:10px;">
-        <button class="btn" type="button" id="age-calc">Calculate Age</button>
-        <button class="btn" type="button" id="age-clear">Clear</button>
+        <button class="btn" type="submit">Calculate Age</button>
+        <button class="btn" type="reset">Clear</button>
       </div>
       <p class="helper" style="margin-top:10px;">Tip: Use the calendar button or type a date manually.</p>
     </form>
   </section>
 
-  <section id="age-result" style="margin-top:16px;"></section>
+  <section id="age-result" aria-live="polite" style="margin-top:16px;"></section>
 
   <AdSlot id="age-inline-1" />
+  <script defer src="/js/date-utils.js"></script>
   <script defer src="/js/age-calculator.js"></script>
 </BaseLayout>

--- a/src/pages/calculators/days-from-date.astro
+++ b/src/pages/calculators/days-from-date.astro
@@ -54,15 +54,16 @@ const description = "Calculate days between today and a specific date, or betwee
       </div>
 
       <div style="margin-top:14px; display:flex; gap:10px;">
-        <button class="btn" type="button" id="calc">Calculate</button>
-        <button class="btn" type="button" id="clear">Clear</button>
+        <button class="btn" type="submit">Calculate</button>
+        <button class="btn" type="reset">Clear</button>
       </div>
       <p class="helper" style="margin-top:10px;">Tip: Use the calendar buttons or type a date manually.</p>
     </form>
   </section>
 
-  <section id="result" style="margin-top:16px;"></section>
+  <section id="result" aria-live="polite" style="margin-top:16px;"></section>
 
   <AdSlot id="dfd-inline-1" />
+  <script defer src="/js/date-utils.js"></script>
   <script defer src="/js/days-from-date.js"></script>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,6 +15,12 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
       <span class="btn">Open</span>
     </a>
 
+    <a class="card" href="/calculators/age-calculator">
+      <h3>Age Calculator</h3>
+      <p>Enter a birthdate to see your age in years, months, and days.</p>
+      <span class="btn">Open</span>
+    </a>
+
     <a class="card" href="/calculators/days-until-birthday">
       <h3>Days Until Your Birthday</h3>
       <p>Countdown with leap-year handling for Feb 29 birthdays.</p>


### PR DESCRIPTION
## Summary
- create a dedicated Age Calculator page wired into the existing layout and styling
- add a front-end script that parses birthdates and reports age down to years, months, and days with next-birthday info
- link the new tool from the global navigation and home page card grid

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c867f78fd08323aa2623bbecdb9181