### PR TITLE
Add anniversary countdown calculator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.astro/
+src/env.d.ts

--- a/public/js/anniversary-countdown.js
+++ b/public/js/anniversary-countdown.js
@@ -1,0 +1,138 @@
+(function () {
+  function stripTime(d) { return new Date(d.getFullYear(), d.getMonth(), d.getDate()); }
+  function parseDate(input) {
+    if (!input) return null;
+    const iso = /^(\d{4})-(\d{2})-(\d{2})$/;
+    const us = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/;
+    let y, m, da;
+    if (iso.test(input)) {
+      const m1 = input.match(iso); y = +m1[1]; m = +m1[2]; da = +m1[3];
+    } else if (us.test(input)) {
+      const m2 = input.match(us); m = +m2[1]; da = +m2[2]; y = +m2[3];
+    } else return null;
+    const d = new Date(y, m - 1, da);
+    return d && d.getFullYear() === y && d.getMonth() === m - 1 && d.getDate() === da ? d : null;
+  }
+  function formatISODate(d) {
+    const mm = String(d.getMonth() + 1).padStart(2, "0");
+    const dd = String(d.getDate()).padStart(2, "0");
+    return d.getFullYear() + "-" + mm + "-" + dd;
+  }
+  function plural(n) { return Math.abs(n) === 1 ? "" : "s"; }
+  function ordinal(n) {
+    const mod10 = n % 10;
+    const mod100 = n % 100;
+    if (mod10 === 1 && mod100 !== 11) return n + "st";
+    if (mod10 === 2 && mod100 !== 12) return n + "nd";
+    if (mod10 === 3 && mod100 !== 13) return n + "rd";
+    return n + "th";
+  }
+  function card(html) { return '<section class="card" style="margin-top:16px;">' + html + "</section>"; }
+  function anniversaryDate(base, number) {
+    const year = base.getFullYear() + number;
+    const month = base.getMonth();
+    const day = base.getDate();
+    let d = new Date(year, month, day);
+    if (month === 1 && day === 29 && d.getMonth() !== month) {
+      d = new Date(year, 1, 28);
+    }
+    return stripTime(d);
+  }
+  function setupCalendarPickers() {
+    const fields = document.querySelectorAll(".date-input");
+    fields.forEach((field) => {
+      const textInput = field.querySelector('[data-role="date-text"]');
+      const pickerInput = field.querySelector('[data-role="date-picker"]');
+      const trigger = field.querySelector(".date-trigger");
+      if (!textInput || !pickerInput || !trigger) return;
+
+      const syncPicker = () => {
+        const parsed = parseDate(textInput.value.trim());
+        pickerInput.value = parsed ? formatISODate(parsed) : "";
+      };
+
+      syncPicker();
+
+      trigger.addEventListener("click", () => {
+        syncPicker();
+        if (typeof pickerInput.showPicker === "function") {
+          pickerInput.showPicker();
+        } else {
+          pickerInput.focus();
+          pickerInput.click();
+        }
+      });
+
+      pickerInput.addEventListener("change", () => {
+        if (pickerInput.value) {
+          textInput.value = pickerInput.value;
+          textInput.dispatchEvent(new Event("input", { bubbles: true }));
+        }
+      });
+
+      textInput.addEventListener("input", syncPicker);
+    });
+  }
+
+  const dateEl = document.getElementById("anniversary-date");
+  const calcBtn = document.getElementById("anniversary-calc");
+  const clearBtn = document.getElementById("anniversary-clear");
+  const out = document.getElementById("anniversary-result");
+
+  setupCalendarPickers();
+  if (!dateEl || !calcBtn || !out) return;
+
+  calcBtn.addEventListener("click", () => {
+    const raw = dateEl.value.trim();
+    const parsed = parseDate(raw);
+    if (!parsed) {
+      out.innerHTML = card("<p>Please enter a valid date.</p>");
+      return;
+    }
+
+    const MS = 86400000;
+    const special = stripTime(parsed);
+    const today = stripTime(new Date());
+    const diff = Math.round((today - special) / MS);
+
+    const context = diff === 0
+      ? "That's <strong>today</strong>."
+      : diff > 0
+        ? "That was <strong>" + diff + "</strong> day" + plural(diff) + " ago."
+        : "That's in <strong>" + Math.abs(diff) + "</strong> day" + plural(Math.abs(diff)) + ".";
+
+    const baseYear = special.getFullYear();
+    let annNumber = Math.max(1, today.getFullYear() - baseYear);
+    while (anniversaryDate(special, annNumber) < today) {
+      annNumber += 1;
+    }
+
+    const items = [];
+    for (let i = 0; i < 5; i += 1) {
+      const annDate = anniversaryDate(special, annNumber + i);
+      const daysAway = Math.round((annDate - today) / MS);
+      const when = daysAway === 0
+        ? "<span class=\"helper\">That's today!</span>"
+        : "<span class=\"helper\">In " + daysAway + " day" + plural(daysAway) + ".</span>";
+      items.push(
+        "<li style=\"margin:10px 0;\">" +
+          "<strong>" + ordinal(annNumber + i) + " anniversary</strong> — " +
+          annDate.toDateString() + " " + when +
+        "</li>"
+      );
+    }
+
+    out.innerHTML = card(
+      "<h3>Upcoming Anniversaries</h3>" +
+        "<p class=\"helper\">Original date: <strong>" + special.toDateString() + "</strong>. " + context + "</p>" +
+        "<ul style=\"list-style:none; padding:0; margin:14px 0 0;\">" + items.join("") + "</ul>"
+    );
+  });
+
+  clearBtn && clearBtn.addEventListener("click", () => {
+    dateEl.value = "";
+    out.innerHTML = "";
+    dateEl.dispatchEvent(new Event("input", { bubbles: true }));
+    dateEl.focus();
+  });
+})();

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -31,6 +31,7 @@ const url = new URL(pathname, Astro.site ?? "http://localhost:4321");
         <nav class="nav" aria-label="Main">
           <a href="/calculators/days-from-date">Days From Date</a>
           <a href="/calculators/days-until-birthday">Birthday</a>
+          <a href="/calculators/anniversary-countdown">Anniversary</a>
           <a href="/calculators/holiday-countdown">Holidays</a>
         </nav>
       </div>

--- a/src/pages/calculators/anniversary-countdown.astro
+++ b/src/pages/calculators/anniversary-countdown.astro
@@ -1,0 +1,47 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+const title = "Anniversary Countdown";
+const description = "Input a special date and see upcoming anniversary milestones.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/anniversary-countdown">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">Enter a meaningful date to preview the next anniversaries and days remaining.</p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="anniversary-form">
+      <label for="anniversary-date">Special Date</label>
+      <div class="date-input">
+        <input
+          id="anniversary-date"
+          name="anniversary-date"
+          type="text"
+          inputmode="numeric"
+          placeholder="YYYY-MM-DD or MM/DD/YYYY"
+          data-role="date-text"
+        />
+        <button class="date-trigger" type="button" aria-label="Open calendar for special date">
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path
+              d="M7 2a1 1 0 0 1 1 1v1h8V3a1 1 0 1 1 2 0v1h1.5A2.5 2.5 0 0 1 22 6.5v13A2.5 2.5 0 0 1 19.5 22h-15A2.5 2.5 0 0 1 2 19.5v-13A2.5 2.5 0 0 1 4.5 4H6V3a1 1 0 0 1 1-1Zm0 4H4.5a.5.5 0 0 0-.5.5V8h16V6.5a.5.5 0 0 0-.5-.5H17v1a1 1 0 0 1-2 0V6H8v1a1 1 0 0 1-2 0V6Zm13 4H4v9.5a.5.5 0 0 0 .5.5h15a.5.5 0 0 0 .5-.5V10Z"
+            />
+          </svg>
+        </button>
+        <input type="date" class="date-picker" data-role="date-picker" aria-hidden="true" tabindex="-1" />
+      </div>
+      <p class="helper" style="margin-top:10px;">Use any format above or the calendar button to fill the date.</p>
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="button" id="anniversary-calc">Show Anniversaries</button>
+        <button class="btn" type="button" id="anniversary-clear">Clear</button>
+      </div>
+    </form>
+  </section>
+
+  <section id="anniversary-result" style="margin-top:16px;"></section>
+
+  <AdSlot id="anniversary-inline-1" />
+  <script defer src="/js/anniversary-countdown.js"></script>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -21,6 +21,12 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
       <span class="btn">Open</span>
     </a>
 
+    <a class="card" href="/calculators/anniversary-countdown">
+      <h3>Anniversary Countdown</h3>
+      <p>Preview the next few anniversaries for any meaningful date.</p>
+      <span class="btn">Open</span>
+    </a>
+
     <a class="card" href="/calculators/holiday-countdown">
       <h3>Holiday Countdown (US)</h3>
       <p>See days remaining until major U.S. holidays.</p>


### PR DESCRIPTION
## Summary
- add an anniversary countdown calculator page with date picker styling that matches the site
- implement front-end logic to compute upcoming anniversaries and show days remaining
- surface the new tool in the navigation/home grid and ignore build artifacts in git

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c86ba6f0508323a336e6df82fe65c1