### PR TITLE
Add finance-focused calculators and shared styling utilities

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
+import { defineConfig } from "astro/config";
 
 export default defineConfig({
-  site: 'https://example.com',
-  output: 'static'
+  site: "https://example.com",
+  output: "static",
 });

--- a/public/js/age-calculator.js
+++ b/public/js/age-calculator.js
@@ -1,13 +1,8 @@
 (function () {
   if (typeof window === "undefined" || !window.CalcDate) return;
 
-  const {
-    MS_IN_DAY,
-    parseDate,
-    plural,
-    setupCalendarPickers,
-    stripTime,
-  } = window.CalcDate;
+  const { MS_IN_DAY, parseDate, plural, setupCalendarPickers, stripTime } =
+    window.CalcDate;
 
   const form = document.getElementById("age-form");
   const birthInput = document.getElementById("birthdate");
@@ -24,12 +19,14 @@
   const formatFullDate = (date) =>
     dateFormatter ? dateFormatter.format(date) : date.toDateString();
 
-  const card = (html) => `<section class="card" style="margin-top:16px;">${html}</section>`;
+  const card = (html) =>
+    `<section class="card" style="margin-top:16px;">${html}</section>`;
   const renderError = (message) => {
     output.innerHTML = card(`<p>${message}</p>`);
   };
 
-  const daysInMonth = (year, monthIndex) => new Date(year, monthIndex + 1, 0).getDate();
+  const daysInMonth = (year, monthIndex) =>
+    new Date(year, monthIndex + 1, 0).getDate();
 
   const addMonthsClamped = (date, count, anchorDay) => {
     const anchor = anchorDay ?? date.getDate();

--- a/public/js/anniversary-countdown.js
+++ b/public/js/anniversary-countdown.js
@@ -1,24 +1,39 @@
 (function () {
-  function stripTime(d) { return new Date(d.getFullYear(), d.getMonth(), d.getDate()); }
+  function stripTime(d) {
+    return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  }
   function parseDate(input) {
     if (!input) return null;
     const iso = /^(\d{4})-(\d{2})-(\d{2})$/;
     const us = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/;
     let y, m, da;
     if (iso.test(input)) {
-      const m1 = input.match(iso); y = +m1[1]; m = +m1[2]; da = +m1[3];
+      const m1 = input.match(iso);
+      y = +m1[1];
+      m = +m1[2];
+      da = +m1[3];
     } else if (us.test(input)) {
-      const m2 = input.match(us); m = +m2[1]; da = +m2[2]; y = +m2[3];
+      const m2 = input.match(us);
+      m = +m2[1];
+      da = +m2[2];
+      y = +m2[3];
     } else return null;
     const d = new Date(y, m - 1, da);
-    return d && d.getFullYear() === y && d.getMonth() === m - 1 && d.getDate() === da ? d : null;
+    return d &&
+      d.getFullYear() === y &&
+      d.getMonth() === m - 1 &&
+      d.getDate() === da
+      ? d
+      : null;
   }
   function formatISODate(d) {
     const mm = String(d.getMonth() + 1).padStart(2, "0");
     const dd = String(d.getDate()).padStart(2, "0");
     return d.getFullYear() + "-" + mm + "-" + dd;
   }
-  function plural(n) { return Math.abs(n) === 1 ? "" : "s"; }
+  function plural(n) {
+    return Math.abs(n) === 1 ? "" : "s";
+  }
   function ordinal(n) {
     const mod10 = n % 10;
     const mod100 = n % 100;
@@ -27,7 +42,11 @@
     if (mod10 === 3 && mod100 !== 13) return n + "rd";
     return n + "th";
   }
-  function card(html) { return '<section class="card" style="margin-top:16px;">' + html + "</section>"; }
+  function card(html) {
+    return (
+      '<section class="card" style="margin-top:16px;">' + html + "</section>"
+    );
+  }
   function anniversaryDate(base, number) {
     const year = base.getFullYear() + number;
     const month = base.getMonth();
@@ -95,11 +114,20 @@
     const today = stripTime(new Date());
     const diff = Math.round((today - special) / MS);
 
-    const context = diff === 0
-      ? "That's <strong>today</strong>."
-      : diff > 0
-        ? "That was <strong>" + diff + "</strong> day" + plural(diff) + " ago."
-        : "That's in <strong>" + Math.abs(diff) + "</strong> day" + plural(Math.abs(diff)) + ".";
+    const context =
+      diff === 0
+        ? "That's <strong>today</strong>."
+        : diff > 0
+          ? "That was <strong>" +
+            diff +
+            "</strong> day" +
+            plural(diff) +
+            " ago."
+          : "That's in <strong>" +
+            Math.abs(diff) +
+            "</strong> day" +
+            plural(Math.abs(diff)) +
+            ".";
 
     const baseYear = special.getFullYear();
     let annNumber = Math.max(1, today.getFullYear() - baseYear);
@@ -111,28 +139,44 @@
     for (let i = 0; i < 5; i += 1) {
       const annDate = anniversaryDate(special, annNumber + i);
       const daysAway = Math.round((annDate - today) / MS);
-      const when = daysAway === 0
-        ? "<span class=\"helper\">That's today!</span>"
-        : "<span class=\"helper\">In " + daysAway + " day" + plural(daysAway) + ".</span>";
+      const when =
+        daysAway === 0
+          ? '<span class="helper">That\'s today!</span>'
+          : '<span class="helper">In ' +
+            daysAway +
+            " day" +
+            plural(daysAway) +
+            ".</span>";
       items.push(
-        "<li style=\"margin:10px 0;\">" +
-          "<strong>" + ordinal(annNumber + i) + " anniversary</strong> — " +
-          annDate.toDateString() + " " + when +
-        "</li>"
+        '<li style="margin:10px 0;">' +
+          "<strong>" +
+          ordinal(annNumber + i) +
+          " anniversary</strong> — " +
+          annDate.toDateString() +
+          " " +
+          when +
+          "</li>",
       );
     }
 
     out.innerHTML = card(
       "<h3>Upcoming Anniversaries</h3>" +
-        "<p class=\"helper\">Original date: <strong>" + special.toDateString() + "</strong>. " + context + "</p>" +
-        "<ul style=\"list-style:none; padding:0; margin:14px 0 0;\">" + items.join("") + "</ul>"
+        '<p class="helper">Original date: <strong>' +
+        special.toDateString() +
+        "</strong>. " +
+        context +
+        "</p>" +
+        '<ul style="list-style:none; padding:0; margin:14px 0 0;">' +
+        items.join("") +
+        "</ul>",
     );
   });
 
-  clearBtn && clearBtn.addEventListener("click", () => {
-    dateEl.value = "";
-    out.innerHTML = "";
-    dateEl.dispatchEvent(new Event("input", { bubbles: true }));
-    dateEl.focus();
-  });
+  clearBtn &&
+    clearBtn.addEventListener("click", () => {
+      dateEl.value = "";
+      out.innerHTML = "";
+      dateEl.dispatchEvent(new Event("input", { bubbles: true }));
+      dateEl.focus();
+    });
 })();

--- a/public/js/compound-interest.js
+++ b/public/js/compound-interest.js
@@ -1,0 +1,158 @@
+(function () {
+  const form = document.getElementById("compound-form");
+  const resultEl = document.getElementById("compound-result");
+
+  if (!form || !resultEl) return;
+
+  const currencyFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+
+  const percentFormatter = new Intl.NumberFormat("en-US", {
+    style: "percent",
+    maximumFractionDigits: 2,
+  });
+
+  function parseNumber(value) {
+    const num = parseFloat(value);
+    return Number.isFinite(num) ? num : 0;
+  }
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const data = new FormData(form);
+
+    const principal = parseNumber(data.get("principal"));
+    const contribution = parseNumber(data.get("contribution"));
+    const annualRate = parseNumber(data.get("rate"));
+    const years = parseInt(data.get("years"), 10);
+    const frequency = String(data.get("frequency"));
+    const raisePercent = parseNumber(data.get("raise"));
+
+    if (
+      principal < 0 ||
+      !years ||
+      years <= 0 ||
+      annualRate < 0 ||
+      contribution < 0 ||
+      raisePercent < 0
+    ) {
+      resultEl.innerHTML = `<section class="card"><p>Double-check your inputs. We need non-negative values and at least one year of growth.</p></section>`;
+      return;
+    }
+
+    const periodsPerYear =
+      {
+        annually: 1,
+        quarterly: 4,
+        monthly: 12,
+        daily: 365,
+      }[frequency] || 12;
+
+    const effectiveAnnualRate = annualRate / 100;
+    const monthlyRate =
+      periodsPerYear > 0
+        ? Math.pow(
+            1 + effectiveAnnualRate / periodsPerYear,
+            periodsPerYear / 12,
+          ) - 1
+        : 0;
+    const months = years * 12;
+    const raiseRate = raisePercent > 0 ? raisePercent / 100 : 0;
+
+    let balance = principal;
+    let currentContribution = contribution;
+    let lastContribution = contribution;
+    let totalContributions = principal;
+    const schedule = [];
+
+    for (let month = 1; month <= months; month += 1) {
+      const growth = balance * monthlyRate;
+      balance += growth;
+
+      balance += currentContribution;
+      totalContributions += currentContribution;
+      lastContribution = currentContribution;
+
+      const yearIndex = Math.ceil(month / 12) - 1;
+      if (!schedule[yearIndex]) {
+        schedule[yearIndex] = {
+          year: yearIndex + 1,
+          contributions: 0,
+          growth: 0,
+          balance: 0,
+        };
+      }
+
+      schedule[yearIndex].contributions += currentContribution;
+      schedule[yearIndex].growth += growth;
+      schedule[yearIndex].balance = balance;
+
+      if (raiseRate > 0 && month % 12 === 0) {
+        currentContribution *= 1 + raiseRate;
+      }
+    }
+
+    const totalGrowth = balance - totalContributions;
+    const avgAnnualReturn =
+      years > 0 && totalContributions > 0
+        ? Math.pow(balance / totalContributions, 1 / years) - 1
+        : effectiveAnnualRate;
+
+    const rows = schedule
+      .map((entry) => {
+        return `<tr><td>Year ${entry.year}</td><td>${currencyFormatter.format(entry.contributions)}</td><td>${currencyFormatter.format(entry.growth)}</td><td>${currencyFormatter.format(entry.balance)}</td></tr>`;
+      })
+      .join("");
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">Projected balance after ${years} year${years === 1 ? "" : "s"}</h2>
+        <div class="stat-grid">
+          <div class="stat">
+            <span class="label">Future value</span>
+            <span class="value">${currencyFormatter.format(balance)}</span>
+          </div>
+          <div class="stat">
+            <span class="label">Total contributed</span>
+            <span class="value">${currencyFormatter.format(totalContributions)}</span>
+          </div>
+          <div class="stat">
+            <span class="label">Growth earned</span>
+            <span class="value">${currencyFormatter.format(totalGrowth)}</span>
+          </div>
+          <div class="stat">
+            <span class="label">Last monthly deposit</span>
+            <span class="value">${currencyFormatter.format(lastContribution)}</span>
+          </div>
+          <div class="stat">
+            <span class="label">Avg. annualized return</span>
+            <span class="value">${percentFormatter.format(avgAnnualReturn)}</span>
+          </div>
+        </div>
+        <p class="helper" style="margin-top:12px;">Returns assume smooth growth—real markets bounce around. Adjust contributions yearly to reflect expected raises.</p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Year</th>
+                <th>Contributions</th>
+                <th>Growth</th>
+                <th>Ending balance</th>
+              </tr>
+            </thead>
+            <tbody>${rows}</tbody>
+          </table>
+        </div>
+      </section>
+    `;
+  });
+
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+})();

--- a/public/js/currency-converter.js
+++ b/public/js/currency-converter.js
@@ -1,0 +1,226 @@
+(function () {
+  const form = document.getElementById("currency-form");
+  const resultEl = document.getElementById("currency-result");
+  const fromSelect = document.getElementById("currency-from");
+  const toSelect = document.getElementById("currency-to");
+  const swapButton = document.getElementById("currency-swap");
+  const statusEl = document.getElementById("currency-status");
+
+  if (!form || !resultEl || !fromSelect || !toSelect) return;
+
+  const currencies = [
+    { code: "USD", name: "US Dollar" },
+    { code: "EUR", name: "Euro" },
+    { code: "GBP", name: "British Pound" },
+    { code: "CAD", name: "Canadian Dollar" },
+    { code: "AUD", name: "Australian Dollar" },
+    { code: "NZD", name: "New Zealand Dollar" },
+    { code: "JPY", name: "Japanese Yen" },
+    { code: "CNY", name: "Chinese Yuan" },
+    { code: "INR", name: "Indian Rupee" },
+    { code: "CHF", name: "Swiss Franc" },
+    { code: "SEK", name: "Swedish Krona" },
+    { code: "NOK", name: "Norwegian Krone" },
+    { code: "MXN", name: "Mexican Peso" },
+    { code: "BRL", name: "Brazilian Real" },
+    { code: "ZAR", name: "South African Rand" },
+    { code: "SGD", name: "Singapore Dollar" },
+    { code: "HKD", name: "Hong Kong Dollar" },
+    { code: "KRW", name: "South Korean Won" },
+    { code: "PLN", name: "Polish Złoty" },
+    { code: "DKK", name: "Danish Krone" },
+    { code: "TRY", name: "Turkish Lira" },
+    { code: "AED", name: "UAE Dirham" },
+    { code: "SAR", name: "Saudi Riyal" },
+    { code: "ILS", name: "Israeli Shekel" },
+    { code: "MYR", name: "Malaysian Ringgit" },
+    { code: "IDR", name: "Indonesian Rupiah" },
+    { code: "PHP", name: "Philippine Peso" },
+    { code: "THB", name: "Thai Baht" },
+    { code: "ARS", name: "Argentine Peso" },
+    { code: "CLP", name: "Chilean Peso" },
+  ];
+
+  const fallbackRates = {
+    USD: 1,
+    EUR: 0.92,
+    GBP: 0.79,
+    CAD: 1.36,
+    AUD: 1.53,
+    NZD: 1.66,
+    JPY: 150.25,
+    CNY: 7.18,
+    INR: 83.2,
+    CHF: 0.87,
+    SEK: 10.5,
+    NOK: 10.8,
+    MXN: 17.1,
+    BRL: 5.15,
+    ZAR: 18.2,
+    SGD: 1.35,
+    HKD: 7.82,
+    KRW: 1340,
+    PLN: 3.99,
+    DKK: 6.85,
+    TRY: 30.5,
+    AED: 3.67,
+    SAR: 3.75,
+    ILS: 3.72,
+    MYR: 4.72,
+    IDR: 15500,
+    PHP: 55.7,
+    THB: 34.5,
+    ARS: 825,
+    CLP: 870,
+  };
+
+  const rateState = {
+    base: "USD",
+    rates: { ...fallbackRates },
+    updated: "Using offline fallback rates",
+    source: "offline",
+  };
+
+  function populateSelects() {
+    const options = currencies
+      .map(
+        (currency) =>
+          `<option value="${currency.code}">${currency.code} — ${currency.name}</option>`,
+      )
+      .join("");
+    fromSelect.innerHTML = options;
+    toSelect.innerHTML = options;
+    fromSelect.value = "USD";
+    toSelect.value = "EUR";
+  }
+
+  function updateStatus(message, isError = false) {
+    if (statusEl) {
+      statusEl.textContent = message;
+      statusEl.style.color = isError ? "#ff6b6b" : "var(--muted)";
+    }
+  }
+
+  function convert(amount, from, to) {
+    const fromRate = rateState.rates[from];
+    const toRate = rateState.rates[to];
+    if (!fromRate || !toRate) return null;
+    const baseAmount = amount / fromRate;
+    return baseAmount * toRate;
+  }
+
+  function renderResult(amount, from, to) {
+    if (!amount || amount < 0) {
+      resultEl.innerHTML = "";
+      return;
+    }
+
+    const converted = convert(amount, from, to);
+    if (converted === null) {
+      resultEl.innerHTML = `<section class="card"><p>We don't have rates for that pair right now.</p></section>`;
+      return;
+    }
+
+    const rate = convert(1, from, to);
+    const formatterFrom = new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: from,
+    });
+    const formatterTo = new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: to,
+    });
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">${formatterFrom.format(amount)} = ${formatterTo.format(converted)}</h2>
+        <p class="helper" style="margin-top:8px;">1 ${from} = ${formatterTo.format(rate)} · Rates ${rateState.updated}</p>
+      </section>
+    `;
+  }
+
+  async function fetchRates() {
+    updateStatus("Updating rates…");
+    try {
+      const response = await fetch("https://open.er-api.com/v6/latest/USD");
+      if (!response.ok) {
+        throw new Error("Network response was not ok");
+      }
+      const data = await response.json();
+      if (data.result !== "success" || !data.rates) {
+        throw new Error("Unexpected API response");
+      }
+      rateState.base = data.base_code || "USD";
+      rateState.rates = { ...data.rates, [rateState.base]: 1 };
+      rateState.updated = `updated ${data.time_last_update_utc || "recently"}`;
+      rateState.source = "live";
+      updateStatus(`Live rates ${rateState.updated}`);
+    } catch (error) {
+      console.error("Currency fetch failed", error);
+      rateState.base = "USD";
+      rateState.rates = { ...fallbackRates };
+      rateState.updated =
+        "using fallback rates (check back online for live data)";
+      rateState.source = "offline";
+      updateStatus(
+        "Using cached sample rates. Connect to the internet for fresh data.",
+        true,
+      );
+    }
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    const amount = parseFloat(form.amount.value || "0");
+    const from = fromSelect.value;
+    const to = toSelect.value;
+    if (!Number.isFinite(amount) || amount < 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter an amount of zero or more to convert.</p></section>`;
+      return;
+    }
+    renderResult(amount, from, to);
+  }
+
+  function handleSwap() {
+    const currentFrom = fromSelect.value;
+    fromSelect.value = toSelect.value;
+    toSelect.value = currentFrom;
+    const amount = parseFloat(form.amount.value || "0");
+    if (Number.isFinite(amount)) {
+      renderResult(amount, fromSelect.value, toSelect.value);
+    }
+  }
+
+  populateSelects();
+  fetchRates().then(() => {
+    const amount = parseFloat(form.amount.value || "0");
+    renderResult(
+      Number.isFinite(amount) ? amount : 0,
+      fromSelect.value,
+      toSelect.value,
+    );
+  });
+
+  form.addEventListener("submit", handleSubmit);
+  fromSelect.addEventListener("change", () => {
+    const amount = parseFloat(form.amount.value || "0");
+    if (Number.isFinite(amount)) {
+      renderResult(amount, fromSelect.value, toSelect.value);
+    }
+  });
+  toSelect.addEventListener("change", () => {
+    const amount = parseFloat(form.amount.value || "0");
+    if (Number.isFinite(amount)) {
+      renderResult(amount, fromSelect.value, toSelect.value);
+    }
+  });
+  form.amount.addEventListener("input", () => {
+    const amount = parseFloat(form.amount.value || "0");
+    if (Number.isFinite(amount)) {
+      renderResult(amount, fromSelect.value, toSelect.value);
+    }
+  });
+  if (swapButton) {
+    swapButton.addEventListener("click", handleSwap);
+  }
+})();

--- a/public/js/date-utils.js
+++ b/public/js/date-utils.js
@@ -55,7 +55,8 @@
   }
 
   function setupCalendarPickers(root = document) {
-    const scope = root && typeof root.querySelectorAll === "function" ? root : document;
+    const scope =
+      root && typeof root.querySelectorAll === "function" ? root : document;
     const fields = scope.querySelectorAll(".date-input");
     fields.forEach((field) => {
       if (field.dataset.datePickerReady === "true") return;

--- a/public/js/days-from-date.js
+++ b/public/js/days-from-date.js
@@ -1,13 +1,8 @@
 (function () {
   if (typeof window === "undefined" || !window.CalcDate) return;
 
-  const {
-    MS_IN_DAY,
-    parseDate,
-    plural,
-    setupCalendarPickers,
-    stripTime,
-  } = window.CalcDate;
+  const { MS_IN_DAY, parseDate, plural, setupCalendarPickers, stripTime } =
+    window.CalcDate;
 
   const form = document.getElementById("dfd-form");
   const dateInput = document.getElementById("date");
@@ -25,7 +20,8 @@
   const formatFullDate = (date) =>
     dateFormatter ? dateFormatter.format(date) : date.toDateString();
 
-  const card = (html) => `<section class="card" style="margin-top:16px;">${html}</section>`;
+  const card = (html) =>
+    `<section class="card" style="margin-top:16px;">${html}</section>`;
 
   const daysBetween = (start, end) => {
     return Math.round((stripTime(end) - stripTime(start)) / MS_IN_DAY);
@@ -35,7 +31,9 @@
     const targetRaw = dateInput.value.trim();
     const compareRaw = compareInput.value.trim();
     const target = parseDate(targetRaw);
-    const comparison = compareRaw ? parseDate(compareRaw) : stripTime(new Date());
+    const comparison = compareRaw
+      ? parseDate(compareRaw)
+      : stripTime(new Date());
 
     if (!target || !comparison) {
       output.innerHTML = card("<p>Please enter valid date(s).</p>");

--- a/public/js/days-until-birthday.js
+++ b/public/js/days-until-birthday.js
@@ -1,18 +1,28 @@
 (function () {
-  function stripTime(d) { return new Date(d.getFullYear(), d.getMonth(), d.getDate()); }
-  function isLeapYear(y) { return (y % 4 === 0 && y % 100 !== 0) || (y % 400 === 0); }
+  function stripTime(d) {
+    return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  }
+  function isLeapYear(y) {
+    return (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0;
+  }
   function nextBirthday(from, month, day) {
     const y = from.getFullYear();
     let target = new Date(y, month - 1, day);
-    if (month === 2 && day === 29 && !isLeapYear(y)) target = new Date(y, 1, 28);
+    if (month === 2 && day === 29 && !isLeapYear(y))
+      target = new Date(y, 1, 28);
     if (stripTime(target) < stripTime(from)) {
       const ny = y + 1;
       target = new Date(ny, month - 1, day);
-      if (month === 2 && day === 29 && !isLeapYear(ny)) target = new Date(ny, 1, 28);
+      if (month === 2 && day === 29 && !isLeapYear(ny))
+        target = new Date(ny, 1, 28);
     }
     return stripTime(target);
   }
-  function card(html) { return '<section class="card" style="margin-top:16px;">' + html + "</section>"; }
+  function card(html) {
+    return (
+      '<section class="card" style="margin-top:16px;">' + html + "</section>"
+    );
+  }
 
   const mEl = document.getElementById("month");
   const dEl = document.getElementById("day");
@@ -32,10 +42,20 @@
     const nb = nextBirthday(today, m, d);
     const diff = Math.round((nb - today) / 86400000);
     out.innerHTML = card(
-      '<h3>Result</h3><p>Your next birthday is <strong>' + nb.toDateString() +
-      "</strong> — in <strong>" + diff + "</strong> day" + (diff === 1 ? "" : "s") + ".</p>"
+      "<h3>Result</h3><p>Your next birthday is <strong>" +
+        nb.toDateString() +
+        "</strong> — in <strong>" +
+        diff +
+        "</strong> day" +
+        (diff === 1 ? "" : "s") +
+        ".</p>",
     );
   });
 
-  clear && clear.addEventListener("click", () => { dEl.value = ""; out.innerHTML = ""; dEl.focus(); });
+  clear &&
+    clear.addEventListener("click", () => {
+      dEl.value = "";
+      out.innerHTML = "";
+      dEl.focus();
+    });
 })();

--- a/public/js/holiday-countdown.js
+++ b/public/js/holiday-countdown.js
@@ -1,5 +1,7 @@
 (function () {
-  function stripTime(d) { return new Date(d.getFullYear(), d.getMonth(), d.getDate()); }
+  function stripTime(d) {
+    return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  }
   function nthWeekdayOfMonth(year, weekday, month, n) {
     const first = new Date(year, month, 1);
     const delta = (7 + weekday - first.getDay()) % 7;
@@ -12,14 +14,42 @@
   }
   const HOLIDAYS = [
     { key: "new-year", name: "New Year's Day", date: (y) => new Date(y, 0, 1) },
-    { key: "mlk-day", name: "MLK Day", date: (y) => nthWeekdayOfMonth(y, 1, 0, 3) }, // Monday in Jan (weekday=1)
-    { key: "memorial-day", name: "Memorial Day", date: (y) => lastWeekdayOfMonth(y, 1, 4) }, // Monday in May
-    { key: "independence-day", name: "Independence Day", date: (y) => new Date(y, 6, 4) },
-    { key: "labor-day", name: "Labor Day", date: (y) => nthWeekdayOfMonth(y, 1, 8, 1) }, // first Monday in Sep
-    { key: "thanksgiving", name: "Thanksgiving", date: (y) => nthWeekdayOfMonth(y, 4, 10, 4) }, // fourth Thursday in Nov
-    { key: "christmas", name: "Christmas Day", date: (y) => new Date(y, 11, 25) }
+    {
+      key: "mlk-day",
+      name: "MLK Day",
+      date: (y) => nthWeekdayOfMonth(y, 1, 0, 3),
+    }, // Monday in Jan (weekday=1)
+    {
+      key: "memorial-day",
+      name: "Memorial Day",
+      date: (y) => lastWeekdayOfMonth(y, 1, 4),
+    }, // Monday in May
+    {
+      key: "independence-day",
+      name: "Independence Day",
+      date: (y) => new Date(y, 6, 4),
+    },
+    {
+      key: "labor-day",
+      name: "Labor Day",
+      date: (y) => nthWeekdayOfMonth(y, 1, 8, 1),
+    }, // first Monday in Sep
+    {
+      key: "thanksgiving",
+      name: "Thanksgiving",
+      date: (y) => nthWeekdayOfMonth(y, 4, 10, 4),
+    }, // fourth Thursday in Nov
+    {
+      key: "christmas",
+      name: "Christmas Day",
+      date: (y) => new Date(y, 11, 25),
+    },
   ];
-  function card(html) { return '<section class="card" style="margin-top:16px;">' + html + "</section>"; }
+  function card(html) {
+    return (
+      '<section class="card" style="margin-top:16px;">' + html + "</section>"
+    );
+  }
 
   const select = document.getElementById("holiday");
   const btn = document.getElementById("holiday-calc");
@@ -27,16 +57,20 @@
   if (!select || !btn || !out) return;
 
   // Populate dropdown
-  HOLIDAYS.forEach(h => {
+  HOLIDAYS.forEach((h) => {
     const opt = document.createElement("option");
-    opt.value = h.key; opt.textContent = h.name;
+    opt.value = h.key;
+    opt.textContent = h.name;
     select.appendChild(opt);
   });
 
   btn.addEventListener("click", () => {
     const key = select.value;
-    const h = HOLIDAYS.find(x => x.key === key);
-    if (!h) { out.innerHTML = card("<p>Invalid holiday.</p>"); return; }
+    const h = HOLIDAYS.find((x) => x.key === key);
+    if (!h) {
+      out.innerHTML = card("<p>Invalid holiday.</p>");
+      return;
+    }
 
     const today = stripTime(new Date());
     let target = stripTime(h.date(today.getFullYear()));
@@ -44,9 +78,15 @@
 
     const diff = Math.round((target - today) / 86400000);
     out.innerHTML = card(
-      "<h3>" + h.name + "</h3><p>" +
-      target.toDateString() + " — <strong>" + diff + "</strong> day" +
-      (diff === 1 ? "" : "s") + " remaining.</p>"
+      "<h3>" +
+        h.name +
+        "</h3><p>" +
+        target.toDateString() +
+        " — <strong>" +
+        diff +
+        "</strong> day" +
+        (diff === 1 ? "" : "s") +
+        " remaining.</p>",
     );
   });
 })();

--- a/public/js/inflation-calculator.js
+++ b/public/js/inflation-calculator.js
@@ -1,0 +1,190 @@
+(function () {
+  const form = document.getElementById("inflation-form");
+  const resultEl = document.getElementById("inflation-result");
+  const startSelect = document.getElementById("inflation-start");
+  const endSelect = document.getElementById("inflation-end");
+
+  if (!form || !resultEl || !startSelect || !endSelect) return;
+
+  const CPI_DATA = [
+    { year: 1980, cpi: 82.4 },
+    { year: 1981, cpi: 90.9 },
+    { year: 1982, cpi: 96.5 },
+    { year: 1983, cpi: 99.6 },
+    { year: 1984, cpi: 103.9 },
+    { year: 1985, cpi: 107.6 },
+    { year: 1986, cpi: 109.6 },
+    { year: 1987, cpi: 113.6 },
+    { year: 1988, cpi: 118.3 },
+    { year: 1989, cpi: 124.0 },
+    { year: 1990, cpi: 130.7 },
+    { year: 1991, cpi: 136.2 },
+    { year: 1992, cpi: 140.3 },
+    { year: 1993, cpi: 144.5 },
+    { year: 1994, cpi: 148.2 },
+    { year: 1995, cpi: 152.4 },
+    { year: 1996, cpi: 156.9 },
+    { year: 1997, cpi: 160.5 },
+    { year: 1998, cpi: 163.0 },
+    { year: 1999, cpi: 166.6 },
+    { year: 2000, cpi: 172.2 },
+    { year: 2001, cpi: 177.1 },
+    { year: 2002, cpi: 179.9 },
+    { year: 2003, cpi: 184.0 },
+    { year: 2004, cpi: 188.9 },
+    { year: 2005, cpi: 195.3 },
+    { year: 2006, cpi: 201.6 },
+    { year: 2007, cpi: 207.3 },
+    { year: 2008, cpi: 215.3 },
+    { year: 2009, cpi: 214.5 },
+    { year: 2010, cpi: 218.1 },
+    { year: 2011, cpi: 224.9 },
+    { year: 2012, cpi: 229.6 },
+    { year: 2013, cpi: 233.0 },
+    { year: 2014, cpi: 236.7 },
+    { year: 2015, cpi: 237.0 },
+    { year: 2016, cpi: 240.0 },
+    { year: 2017, cpi: 245.1 },
+    { year: 2018, cpi: 251.1 },
+    { year: 2019, cpi: 255.7 },
+    { year: 2020, cpi: 258.8 },
+    { year: 2021, cpi: 271.0 },
+    { year: 2022, cpi: 292.7 },
+    { year: 2023, cpi: 305.3 },
+  ];
+
+  const currencyFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+
+  const percentFormatter = new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 2,
+  });
+
+  function populateYears() {
+    const options = CPI_DATA.map(
+      (entry) => `<option value="${entry.year}">${entry.year}</option>`,
+    ).join("");
+    startSelect.innerHTML = options;
+    endSelect.innerHTML = options;
+    startSelect.value = "2000";
+    endSelect.value = String(CPI_DATA[CPI_DATA.length - 1].year);
+  }
+
+  function findCpi(year) {
+    return CPI_DATA.find((entry) => entry.year === year)?.cpi ?? null;
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    const amount = parseFloat(form.amount.value || "0");
+    const startYear = parseInt(startSelect.value, 10);
+    const endYear = parseInt(endSelect.value, 10);
+
+    if (!Number.isFinite(amount) || amount < 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter an amount of zero or more.</p></section>`;
+      return;
+    }
+
+    if (!Number.isFinite(startYear) || !Number.isFinite(endYear)) {
+      resultEl.innerHTML = `<section class="card"><p>Select start and end years within the dataset.</p></section>`;
+      return;
+    }
+
+    if (startYear === endYear) {
+      resultEl.innerHTML = `<section class="card"><h2 style="margin-top:0;">${currencyFormatter.format(amount)} in ${startYear} is still ${currencyFormatter.format(amount)} in ${endYear}</h2><p class="helper" style="margin-top:8px;">Same-year comparisons have no inflation effect.</p></section>`;
+      return;
+    }
+
+    const startCpi = findCpi(startYear);
+    const endCpi = findCpi(endYear);
+
+    if (!startCpi || !endCpi) {
+      resultEl.innerHTML = `<section class="card"><p>Year selection is outside our CPI data range.</p></section>`;
+      return;
+    }
+
+    const ratio = endCpi / startCpi;
+    const adjustedAmount = amount * ratio;
+    const changePercent = (ratio - 1) * 100;
+    const yearsApart = Math.abs(endYear - startYear);
+    const avgAnnual = Math.pow(ratio, 1 / yearsApart) - 1;
+
+    const [minYear, maxYear] =
+      startYear < endYear ? [startYear, endYear] : [endYear, startYear];
+    const tableRows = CPI_DATA.filter(
+      (entry) => entry.year >= minYear && entry.year <= maxYear,
+    )
+      .map((entry, index, arr) => {
+        const equivalent = amount * (entry.cpi / startCpi);
+        let yoy = 0;
+        if (index > 0) {
+          const prev = arr[index - 1];
+          yoy = (entry.cpi / prev.cpi - 1) * 100;
+        }
+        return `<tr><td>${entry.year}</td><td>${entry.cpi.toFixed(1)}</td><td>${currencyFormatter.format(equivalent)}</td><td>${index === 0 ? "—" : percentFormatter.format(yoy) + "%"}</td></tr>`;
+      })
+      .join("");
+
+    const summary =
+      startYear < endYear
+        ? `${currencyFormatter.format(amount)} in ${startYear} has the buying power of ${currencyFormatter.format(adjustedAmount)} in ${endYear}.`
+        : `${currencyFormatter.format(amount)} in ${startYear} would be worth ${currencyFormatter.format(adjustedAmount)} in ${endYear}.`;
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">${summary}</h2>
+        <div class="stat-grid">
+          <div class="stat">
+            <span class="label">Total inflation</span>
+            <span class="value">${percentFormatter.format(changePercent)}%</span>
+          </div>
+          <div class="stat">
+            <span class="label">Average annual</span>
+            <span class="value">${percentFormatter.format(avgAnnual * 100)}%</span>
+          </div>
+          <div class="stat">
+            <span class="label">Years apart</span>
+            <span class="value">${yearsApart}</span>
+          </div>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Year</th>
+                <th>CPI-U</th>
+                <th>Value of ${currencyFormatter.format(amount)}</th>
+                <th>YoY change</th>
+              </tr>
+            </thead>
+            <tbody>${tableRows}</tbody>
+          </table>
+        </div>
+      </section>
+    `;
+  }
+
+  populateYears();
+  form.addEventListener("submit", handleSubmit);
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      populateYears();
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+
+  startSelect.addEventListener("change", () => {
+    if (parseInt(startSelect.value, 10) > parseInt(endSelect.value, 10)) {
+      endSelect.value = startSelect.value;
+    }
+  });
+
+  endSelect.addEventListener("change", () => {
+    if (parseInt(endSelect.value, 10) < parseInt(startSelect.value, 10)) {
+      startSelect.value = endSelect.value;
+    }
+  });
+})();

--- a/public/js/loan-calculator.js
+++ b/public/js/loan-calculator.js
@@ -1,0 +1,148 @@
+(function () {
+  const form = document.getElementById("loan-form");
+  const resultEl = document.getElementById("loan-result");
+
+  if (!form || !resultEl) return;
+
+  const currencyFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const formData = new FormData(form);
+    const amount = parseFloat(formData.get("amount"));
+    const rate = parseFloat(formData.get("rate"));
+    const term = parseInt(formData.get("term"), 10);
+    const extra = parseFloat(formData.get("extra")) || 0;
+
+    if (
+      !isFinite(amount) ||
+      amount <= 0 ||
+      !isFinite(rate) ||
+      rate < 0 ||
+      !isFinite(term) ||
+      term <= 0
+    ) {
+      resultEl.innerHTML = `<section class="card"><p>Please provide a loan amount, interest rate, and term above zero.</p></section>`;
+      return;
+    }
+
+    const monthlyRate = rate > 0 ? rate / 100 / 12 : 0;
+    const totalMonths = term * 12;
+    let monthlyPayment;
+
+    if (monthlyRate === 0) {
+      monthlyPayment = amount / totalMonths;
+    } else {
+      const factor = Math.pow(1 + monthlyRate, totalMonths);
+      monthlyPayment = (amount * monthlyRate * factor) / (factor - 1);
+    }
+
+    monthlyPayment = monthlyPayment + extra;
+    if (!isFinite(monthlyPayment) || monthlyPayment <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Something went wrong. Try adjusting your inputs.</p></section>`;
+      return;
+    }
+
+    let balance = amount;
+    let totalInterest = 0;
+    let totalPaid = 0;
+    const schedule = [];
+    let monthsElapsed = 0;
+
+    for (let month = 1; month <= totalMonths && balance > 0; month += 1) {
+      const interestPayment = monthlyRate > 0 ? balance * monthlyRate : 0;
+      let principalPayment = monthlyPayment - interestPayment;
+      let payment = monthlyPayment;
+
+      if (principalPayment > balance) {
+        principalPayment = balance;
+        payment = principalPayment + interestPayment;
+      }
+
+      balance = Math.max(0, balance - principalPayment);
+      totalInterest += interestPayment;
+      totalPaid += payment;
+
+      const yearIndex = Math.ceil(month / 12) - 1;
+      if (!schedule[yearIndex]) {
+        schedule[yearIndex] = {
+          year: yearIndex + 1,
+          principal: 0,
+          interest: 0,
+          balance: 0,
+          paid: 0,
+        };
+      }
+
+      schedule[yearIndex].principal += principalPayment;
+      schedule[yearIndex].interest += interestPayment;
+      schedule[yearIndex].paid += payment;
+      schedule[yearIndex].balance = balance;
+      monthsElapsed = month;
+
+      if (balance <= 0) {
+        break;
+      }
+    }
+
+    const years = Math.floor(monthsElapsed / 12);
+    const months = monthsElapsed % 12;
+
+    const timeline = schedule
+      .map((item) => {
+        return `<tr><td>Year ${item.year}</td><td>${currencyFormatter.format(item.principal)}</td><td>${currencyFormatter.format(
+          item.interest,
+        )}</td><td>${currencyFormatter.format(item.paid)}</td><td>${currencyFormatter.format(item.balance)}</td></tr>`;
+      })
+      .join("");
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">Monthly payment</h2>
+        <div class="stat-grid">
+          <div class="stat">
+            <span class="label">Payment</span>
+            <span class="value">${currencyFormatter.format(monthlyPayment)}</span>
+          </div>
+          <div class="stat">
+            <span class="label">Total paid</span>
+            <span class="value">${currencyFormatter.format(totalPaid)}</span>
+          </div>
+          <div class="stat">
+            <span class="label">Total interest</span>
+            <span class="value">${currencyFormatter.format(totalInterest)}</span>
+          </div>
+          <div class="stat">
+            <span class="label">Payoff time</span>
+            <span class="value">${years} yrs ${months} mos</span>
+          </div>
+        </div>
+        <p class="helper" style="margin-top:12px;">Numbers are rounded to the nearest cent.</p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Year</th>
+                <th>Principal paid</th>
+                <th>Interest paid</th>
+                <th>Total paid</th>
+                <th>Ending balance</th>
+              </tr>
+            </thead>
+            <tbody>${timeline}</tbody>
+          </table>
+        </div>
+      </section>
+    `;
+  });
+
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+})();

--- a/public/js/mortgage-calculator.js
+++ b/public/js/mortgage-calculator.js
@@ -1,0 +1,249 @@
+(function () {
+  const form = document.getElementById("mortgage-form");
+  const resultEl = document.getElementById("mortgage-result");
+
+  if (!form || !resultEl) return;
+
+  const currencyFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+
+  const percentFormatter = new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 1,
+  });
+
+  function parseNumber(value) {
+    const num = parseFloat(value);
+    return Number.isFinite(num) ? num : 0;
+  }
+
+  function monthlyCostForPrice(
+    price,
+    downPercent,
+    monthlyRate,
+    totalMonths,
+    taxRatePercent,
+    insuranceMonthly,
+    hoaMonthly,
+  ) {
+    const downPayment = price * (downPercent / 100);
+    const loanAmount = Math.max(0, price - downPayment);
+    let monthlyPI = 0;
+
+    if (loanAmount > 0) {
+      if (monthlyRate === 0) {
+        monthlyPI = loanAmount / totalMonths;
+      } else {
+        const factor = Math.pow(1 + monthlyRate, totalMonths);
+        monthlyPI = (loanAmount * monthlyRate * factor) / (factor - 1);
+      }
+    }
+
+    const propertyTaxMonthly =
+      taxRatePercent > 0 ? (price * (taxRatePercent / 100)) / 12 : 0;
+    return monthlyPI + propertyTaxMonthly + insuranceMonthly + hoaMonthly;
+  }
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const data = new FormData(form);
+
+    const price = parseNumber(data.get("price"));
+    const downPercent = parseNumber(data.get("down"));
+    const rate = parseNumber(data.get("rate"));
+    const term = parseInt(data.get("term"), 10);
+    const taxRate = parseNumber(data.get("tax"));
+    const insuranceAnnual = parseNumber(data.get("insurance"));
+    const hoaMonthlyInput = parseNumber(data.get("hoa"));
+    const income = parseNumber(data.get("income"));
+    const debts = parseNumber(data.get("debts"));
+
+    if (
+      !price ||
+      price <= 0 ||
+      !term ||
+      term <= 0 ||
+      downPercent < 0 ||
+      downPercent > 100 ||
+      rate < 0
+    ) {
+      resultEl.innerHTML = `<section class="card"><p>Please enter a valid price, down payment, rate, and term.</p></section>`;
+      return;
+    }
+
+    const downPaymentAmount = price * (downPercent / 100);
+    const loanAmount = Math.max(0, price - downPaymentAmount);
+    const monthlyRate = rate > 0 ? rate / 100 / 12 : 0;
+    const totalMonths = term * 12;
+
+    let monthlyPI = 0;
+    if (loanAmount > 0) {
+      if (monthlyRate === 0) {
+        monthlyPI = loanAmount / totalMonths;
+      } else {
+        const factor = Math.pow(1 + monthlyRate, totalMonths);
+        monthlyPI = (loanAmount * monthlyRate * factor) / (factor - 1);
+      }
+    }
+
+    const propertyTaxMonthly = taxRate > 0 ? (price * (taxRate / 100)) / 12 : 0;
+    const insuranceMonthly = insuranceAnnual > 0 ? insuranceAnnual / 12 : 0;
+    const hoaMonthly = hoaMonthlyInput > 0 ? hoaMonthlyInput : 0;
+
+    const pitiMonthly =
+      monthlyPI + propertyTaxMonthly + insuranceMonthly + hoaMonthly;
+
+    let balance = loanAmount;
+    let totalInterest = 0;
+    let totalPrincipal = 0;
+    let monthsElapsed = 0;
+    const schedule = [];
+
+    if (loanAmount > 0) {
+      for (let month = 1; month <= totalMonths && balance > 0; month += 1) {
+        const interestPayment = monthlyRate > 0 ? balance * monthlyRate : 0;
+        let principalPayment = monthlyPI - interestPayment;
+        let paymentPI = monthlyPI;
+
+        if (principalPayment < 0) {
+          resultEl.innerHTML = `<section class="card"><p>Your payment does not cover the monthly interest. Increase the payment or adjust your rate.</p></section>`;
+          return;
+        }
+
+        if (principalPayment > balance) {
+          principalPayment = balance;
+          paymentPI = principalPayment + interestPayment;
+        }
+
+        balance = Math.max(0, balance - principalPayment);
+        totalInterest += interestPayment;
+        totalPrincipal += principalPayment;
+        monthsElapsed = month;
+
+        const yearIndex = Math.ceil(month / 12) - 1;
+        if (!schedule[yearIndex]) {
+          schedule[yearIndex] = {
+            year: yearIndex + 1,
+            principal: 0,
+            interest: 0,
+            balance: 0,
+          };
+        }
+
+        schedule[yearIndex].principal += principalPayment;
+        schedule[yearIndex].interest += interestPayment;
+        schedule[yearIndex].balance = balance;
+
+        if (balance <= 0) {
+          break;
+        }
+      }
+    }
+
+    const totalTaxesInsurance =
+      (propertyTaxMonthly + insuranceMonthly + hoaMonthly) *
+      (monthsElapsed || totalMonths);
+    const totalOutOfPocket =
+      totalPrincipal + totalInterest + totalTaxesInsurance + downPaymentAmount;
+
+    let dtiValue = null;
+    let affordablePrice = 0;
+    let affordablePayment = 0;
+
+    if (income > 0) {
+      const monthlyIncome = income / 12;
+      affordablePayment = Math.max(0, monthlyIncome * 0.36 - debts);
+      if (monthlyIncome > 0) {
+        dtiValue = ((pitiMonthly + debts) / monthlyIncome) * 100;
+      }
+
+      if (affordablePayment > 0) {
+        let low = 0;
+        let high = Math.max(price * 2, 100000);
+
+        for (let i = 0; i < 40; i += 1) {
+          const mid = (low + high) / 2;
+          const cost = monthlyCostForPrice(
+            mid,
+            downPercent,
+            monthlyRate,
+            totalMonths,
+            taxRate,
+            insuranceMonthly,
+            hoaMonthly,
+          );
+          if (cost > affordablePayment) {
+            high = mid;
+          } else {
+            low = mid;
+          }
+        }
+        affordablePrice = low;
+      }
+    }
+
+    const payoffTotalMonths = loanAmount > 0 ? monthsElapsed || totalMonths : 0;
+    const payoffYears = Math.floor(payoffTotalMonths / 12);
+    const payoffMonths = payoffTotalMonths % 12;
+
+    const rows = schedule
+      .map((entry) => {
+        return `<tr><td>Year ${entry.year}</td><td>${currencyFormatter.format(entry.principal)}</td><td>${currencyFormatter.format(entry.interest)}</td><td>${currencyFormatter.format(entry.balance)}</td></tr>`;
+      })
+      .join("");
+
+    const tableMarkup =
+      loanAmount > 0 && rows
+        ? `<div class="table-wrap"><table><thead><tr><th>Year</th><th>Principal paid</th><th>Interest paid</th><th>Ending balance</th></tr></thead><tbody>${rows}</tbody></table></div>`
+        : `<p class="helper" style="margin-top:12px;">No amortization schedule—this scenario does not require a loan.</p>`;
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">Monthly snapshot</h2>
+        <div class="stat-grid">
+          <div class="stat">
+            <span class="label">Loan amount</span>
+            <span class="value">${currencyFormatter.format(loanAmount)}</span>
+          </div>
+          <div class="stat">
+            <span class="label">Down payment</span>
+            <span class="value">${currencyFormatter.format(downPaymentAmount)}</span>
+          </div>
+          <div class="stat">
+            <span class="label">Principal &amp; interest</span>
+            <span class="value">${currencyFormatter.format(monthlyPI)}</span>
+          </div>
+          <div class="stat">
+            <span class="label">Taxes + insurance + HOA</span>
+            <span class="value">${currencyFormatter.format(propertyTaxMonthly + insuranceMonthly + hoaMonthly)}</span>
+          </div>
+          <div class="stat">
+            <span class="label">Total monthly payment</span>
+            <span class="value">${currencyFormatter.format(pitiMonthly)}</span>
+          </div>
+          <div class="stat">
+            <span class="label">Total interest</span>
+            <span class="value">${currencyFormatter.format(totalInterest)}</span>
+          </div>
+          <div class="stat">
+            <span class="label">Payoff timeline</span>
+            <span class="value">${payoffYears} yrs ${payoffMonths} mos</span>
+          </div>
+          ${dtiValue !== null ? `<div class="stat"><span class="label">Debt-to-income</span><span class="value">${percentFormatter.format(dtiValue)}%</span></div>` : ""}
+          ${affordablePrice > 0 ? `<div class="stat"><span class="label">36% rule home price</span><span class="value">${currencyFormatter.format(affordablePrice)}</span></div>` : ""}
+        </div>
+        ${affordablePayment > 0 ? `<p class="helper" style="margin-top:12px;">Max housing payment at 36% rule: ${currencyFormatter.format(affordablePayment)} (including debts).</p>` : ""}
+        <p class="helper" style="margin-top:12px;">Estimated lifetime cost (including down payment &amp; extras): ${currencyFormatter.format(totalOutOfPocket)}.</p>
+        ${tableMarkup}
+      </section>
+    `;
+  });
+
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+})();

--- a/public/js/salary-hourly.js
+++ b/public/js/salary-hourly.js
@@ -1,0 +1,126 @@
+(function () {
+  const form = document.getElementById("salary-form");
+  const resultEl = document.getElementById("salary-result");
+
+  if (!form || !resultEl) return;
+
+  const annualInput = form.querySelector("#annual-salary");
+  const hourlyInput = form.querySelector("#hourly-rate");
+  const hoursInput = form.querySelector("#hours-week");
+  const weeksInput = form.querySelector("#weeks-year");
+
+  const currencyFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+
+  function formatNumber(value) {
+    return new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(
+      value,
+    );
+  }
+
+  function getSchedule() {
+    const hours = parseFloat(hoursInput.value || "0");
+    const weeks = parseFloat(weeksInput.value || "0");
+    if (
+      !Number.isFinite(hours) ||
+      hours <= 0 ||
+      !Number.isFinite(weeks) ||
+      weeks <= 0
+    ) {
+      resultEl.innerHTML = `<section class="card"><p>Please provide working hours per week and paid weeks per year above zero.</p></section>`;
+      return null;
+    }
+    return { hours, weeks };
+  }
+
+  function renderResult(title, stats) {
+    const statMarkup = stats
+      .map((stat) => {
+        return `<div class="stat"><span class="label">${stat.label}</span><span class="value">${stat.value}</span></div>`;
+      })
+      .join("");
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">${title}</h2>
+        <div class="stat-grid">${statMarkup}</div>
+        <p class="helper" style="margin-top:12px;">Rounded to the nearest cent. Adjust weeks for unpaid leave or overtime expectations.</p>
+      </section>
+    `;
+  }
+
+  function convertAnnualToHourly() {
+    const schedule = getSchedule();
+    if (!schedule) return;
+    const annual = parseFloat(annualInput.value || "0");
+    if (!Number.isFinite(annual) || annual <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Type an annual salary to convert.</p></section>`;
+      return;
+    }
+
+    const hourly = annual / (schedule.weeks * schedule.hours);
+    const weekly = annual / schedule.weeks;
+    const monthly = annual / 12;
+
+    hourlyInput.value = hourly.toFixed(2);
+
+    renderResult(
+      `${currencyFormatter.format(annual)} per year ≈ ${currencyFormatter.format(hourly)} per hour`,
+      [
+        { label: "Hourly", value: currencyFormatter.format(hourly) },
+        { label: "Weekly", value: currencyFormatter.format(weekly) },
+        { label: "Monthly", value: currencyFormatter.format(monthly) },
+        { label: "Weeks counted", value: formatNumber(schedule.weeks) },
+      ],
+    );
+  }
+
+  function convertHourlyToAnnual() {
+    const schedule = getSchedule();
+    if (!schedule) return;
+    const hourly = parseFloat(hourlyInput.value || "0");
+    if (!Number.isFinite(hourly) || hourly <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter an hourly rate to convert.</p></section>`;
+      return;
+    }
+
+    const weekly = hourly * schedule.hours;
+    const annual = weekly * schedule.weeks;
+    const monthly = annual / 12;
+
+    annualInput.value = annual.toFixed(0);
+
+    renderResult(
+      `${currencyFormatter.format(hourly)} per hour ≈ ${currencyFormatter.format(annual)} per year`,
+      [
+        { label: "Annual", value: currencyFormatter.format(annual) },
+        { label: "Weekly", value: currencyFormatter.format(weekly) },
+        { label: "Monthly", value: currencyFormatter.format(monthly) },
+        { label: "Hours weekly", value: formatNumber(schedule.hours) },
+      ],
+    );
+  }
+
+  form.addEventListener("click", (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    const action = target.getAttribute("data-action");
+    if (!action) return;
+
+    event.preventDefault();
+    if (action === "annual-to-hourly") {
+      convertAnnualToHourly();
+    } else if (action === "hourly-to-annual") {
+      convertHourlyToAnnual();
+    }
+  });
+
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+})();

--- a/public/js/savings-goal.js
+++ b/public/js/savings-goal.js
@@ -1,0 +1,142 @@
+(function () {
+  const form = document.getElementById("savings-form");
+  const resultEl = document.getElementById("savings-result");
+
+  if (!form || !resultEl) return;
+
+  const currencyFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+
+  const numberFormatter = new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 2,
+  });
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    const goal = parseFloat(form.goal.value || "0");
+    const current = parseFloat(form.current.value || "0");
+    const years = parseFloat(form.years.value || "0");
+    const rate = parseFloat(form.rate.value || "0");
+
+    if (!Number.isFinite(goal) || goal <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Please enter a savings goal above zero.</p></section>`;
+      return;
+    }
+
+    if (
+      !Number.isFinite(current) ||
+      current < 0 ||
+      !Number.isFinite(years) ||
+      years <= 0
+    ) {
+      resultEl.innerHTML = `<section class="card"><p>Current savings can't be negative and timeframe must be above zero.</p></section>`;
+      return;
+    }
+
+    const months = Math.round(years * 12);
+    if (months <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Your timeframe is too short—choose at least one month.</p></section>`;
+      return;
+    }
+
+    const monthlyRate = rate > 0 ? rate / 100 / 12 : 0;
+    const growthFactor = Math.pow(1 + monthlyRate, months);
+    const futureCurrent = current * growthFactor;
+
+    let monthlyContribution = 0;
+    if (goal > futureCurrent) {
+      if (monthlyRate === 0) {
+        monthlyContribution = (goal - current) / months;
+      } else {
+        monthlyContribution =
+          ((goal - futureCurrent) * monthlyRate) / (growthFactor - 1);
+      }
+    }
+
+    if (!Number.isFinite(monthlyContribution) || monthlyContribution < 0) {
+      resultEl.innerHTML = `<section class="card"><p>We couldn't compute a plan—adjust the goal or timeline.</p></section>`;
+      return;
+    }
+
+    let balance = current;
+    let newContributionTotal = 0;
+    const schedule = [];
+
+    for (let month = 1; month <= months; month += 1) {
+      const interest = balance * monthlyRate;
+      balance += interest;
+
+      balance += monthlyContribution;
+      newContributionTotal += monthlyContribution;
+
+      const yearIndex = Math.ceil(month / 12) - 1;
+      if (!schedule[yearIndex]) {
+        schedule[yearIndex] = {
+          year: yearIndex + 1,
+          contributions: 0,
+          growth: 0,
+          balance: 0,
+        };
+      }
+
+      schedule[yearIndex].contributions += monthlyContribution;
+      schedule[yearIndex].growth += interest;
+      schedule[yearIndex].balance = balance;
+    }
+
+    if (balance < goal) {
+      balance = goal;
+      if (schedule.length > 0) {
+        schedule[schedule.length - 1].balance = balance;
+      }
+    }
+
+    const totalContributions = current + newContributionTotal;
+    const totalGrowth = balance - totalContributions;
+
+    const rows = schedule
+      .map((entry) => {
+        return `<tr><td>Year ${entry.year}</td><td>${currencyFormatter.format(entry.contributions)}</td><td>${currencyFormatter.format(entry.growth)}</td><td>${currencyFormatter.format(entry.balance)}</td></tr>`;
+      })
+      .join("");
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">${monthlyContribution > 0 ? `Save ${currencyFormatter.format(monthlyContribution)} per month` : "No new monthly savings required"}</h2>
+        <div class="stat-grid">
+          <div class="stat"><span class="label">Monthly deposit</span><span class="value">${currencyFormatter.format(monthlyContribution)}</span></div>
+          <div class="stat"><span class="label">Existing savings</span><span class="value">${currencyFormatter.format(current)}</span></div>
+          <div class="stat"><span class="label">New contributions</span><span class="value">${currencyFormatter.format(newContributionTotal)}</span></div>
+          <div class="stat"><span class="label">Total contributions</span><span class="value">${currencyFormatter.format(totalContributions)}</span></div>
+          <div class="stat"><span class="label">Growth earned</span><span class="value">${currencyFormatter.format(totalGrowth)}</span></div>
+          <div class="stat"><span class="label">Projected balance</span><span class="value">${currencyFormatter.format(balance)}</span></div>
+          <div class="stat"><span class="label">Timeline</span><span class="value">${numberFormatter.format(years)} years (${months} months)</span></div>
+        </div>
+        <p class="helper" style="margin-top:12px;">Deposits are assumed at month end. ${monthlyContribution > 0 ? "Consider rounding contributions up to keep a buffer." : "Your existing savings already reach the goal given the assumed growth."}</p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Year</th>
+                <th>Deposits</th>
+                <th>Growth</th>
+                <th>Ending balance</th>
+              </tr>
+            </thead>
+            <tbody>${rows}</tbody>
+          </table>
+        </div>
+      </section>
+    `;
+  }
+
+  form.addEventListener("submit", handleSubmit);
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+})();

--- a/public/js/tip-calculator.js
+++ b/public/js/tip-calculator.js
@@ -1,0 +1,104 @@
+(function () {
+  const form = document.getElementById("tip-form");
+  const resultEl = document.getElementById("tip-result");
+  const tipSelect = document.getElementById("tip-percent");
+  const customWrapper = document.getElementById("custom-tip-wrapper");
+  const customInput = document.getElementById("custom-tip");
+
+  if (!form || !resultEl || !tipSelect || !customWrapper) return;
+
+  const currencyFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+  function showCustomField() {
+    const value = tipSelect.value;
+    if (value === "custom") {
+      customWrapper.style.display = "block";
+      customInput?.focus();
+    } else {
+      customWrapper.style.display = "none";
+    }
+  }
+
+  function renderResult({
+    bill,
+    tipRate,
+    tipAmount,
+    total,
+    perPerson,
+    tipPerPerson,
+    people,
+  }) {
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">${currencyFormatter.format(bill)} bill · ${tipRate.toFixed(1)}% tip</h2>
+        <div class="stat-grid">
+          <div class="stat"><span class="label">Tip amount</span><span class="value">${currencyFormatter.format(tipAmount)}</span></div>
+          <div class="stat"><span class="label">Total with tip</span><span class="value">${currencyFormatter.format(total)}</span></div>
+          <div class="stat"><span class="label">Per person</span><span class="value">${currencyFormatter.format(perPerson)}</span></div>
+          <div class="stat"><span class="label">Tip per person</span><span class="value">${currencyFormatter.format(tipPerPerson)}</span></div>
+          <div class="stat"><span class="label">Split between</span><span class="value">${people} ${people === 1 ? "person" : "people"}</span></div>
+        </div>
+        <p class="helper" style="margin-top:12px;">Round up to avoid shorting the server. Adjust the custom tip for exceptional service.</p>
+      </section>
+    `;
+  }
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const bill = parseFloat(form.bill.value || "0");
+    const people = parseInt(form.people.value || "1", 10);
+
+    if (!Number.isFinite(bill) || bill < 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a bill amount of zero or more.</p></section>`;
+      return;
+    }
+
+    if (!Number.isFinite(people) || people <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>People splitting must be at least one.</p></section>`;
+      return;
+    }
+
+    let tipRate = parseFloat(tipSelect.value);
+    if (Number.isNaN(tipRate)) {
+      const custom = parseFloat(customInput?.value || "0");
+      if (!Number.isFinite(custom) || custom < 0) {
+        resultEl.innerHTML = `<section class="card"><p>Enter a custom tip percentage of zero or more.</p></section>`;
+        return;
+      }
+      tipRate = custom;
+    }
+
+    const tipAmount = bill * (tipRate / 100);
+    const total = bill + tipAmount;
+    const perPerson = total / people;
+    const tipPerPerson = tipAmount / people;
+
+    renderResult({
+      bill,
+      tipRate,
+      tipAmount,
+      total,
+      perPerson,
+      tipPerPerson,
+      people,
+    });
+  });
+
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      resultEl.innerHTML = "";
+      tipSelect.value = "20";
+      customWrapper.style.display = "none";
+      if (customInput) {
+        customInput.value = "";
+      }
+    }, 0);
+  });
+
+  tipSelect.addEventListener("change", showCustomField);
+})();

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -34,6 +34,14 @@ const url = new URL(pathname, Astro.site ?? "http://localhost:4321");
           <a href="/calculators/days-until-birthday">Birthday</a>
           <a href="/calculators/anniversary-countdown">Anniversary</a>
           <a href="/calculators/holiday-countdown">Holidays</a>
+          <a href="/calculators/loan-calculator">Loan</a>
+          <a href="/calculators/mortgage-calculator">Mortgage</a>
+          <a href="/calculators/compound-interest-calculator">Invest</a>
+          <a href="/calculators/currency-converter">Currency</a>
+          <a href="/calculators/inflation-calculator">Inflation</a>
+          <a href="/calculators/salary-to-hourly">Salary</a>
+          <a href="/calculators/tip-calculator">Tip</a>
+          <a href="/calculators/savings-goal-calculator">Savings</a>
         </nav>
       </div>
     </header>

--- a/src/lib/date.js
+++ b/src/lib/date.js
@@ -26,11 +26,31 @@ export function stripTime(d) {
 
 export const US_HOLIDAYS = [
   { key: "new-year", name: "New Year's Day", date: (y) => new Date(y, 0, 1) },
-  { key: "mlk-day", name: "MLK Day", date: (y) => nthWeekdayOfMonth(y, 0, 1, 3) },
-  { key: "memorial-day", name: "Memorial Day", date: (y) => lastWeekdayOfMonth(y, 0, 4) },
-  { key: "independence-day", name: "Independence Day", date: (y) => new Date(y, 6, 4) },
-  { key: "labor-day", name: "Labor Day", date: (y) => nthWeekdayOfMonth(y, 0, 8, 1) },
-  { key: "thanksgiving", name: "Thanksgiving", date: (y) => nthWeekdayOfMonth(y, 4, 10, 4) },
+  {
+    key: "mlk-day",
+    name: "MLK Day",
+    date: (y) => nthWeekdayOfMonth(y, 0, 1, 3),
+  },
+  {
+    key: "memorial-day",
+    name: "Memorial Day",
+    date: (y) => lastWeekdayOfMonth(y, 0, 4),
+  },
+  {
+    key: "independence-day",
+    name: "Independence Day",
+    date: (y) => new Date(y, 6, 4),
+  },
+  {
+    key: "labor-day",
+    name: "Labor Day",
+    date: (y) => nthWeekdayOfMonth(y, 0, 8, 1),
+  },
+  {
+    key: "thanksgiving",
+    name: "Thanksgiving",
+    date: (y) => nthWeekdayOfMonth(y, 4, 10, 4),
+  },
   { key: "christmas", name: "Christmas Day", date: (y) => new Date(y, 11, 25) },
 ];
 

--- a/src/pages/calculators/compound-interest-calculator.astro
+++ b/src/pages/calculators/compound-interest-calculator.astro
@@ -1,0 +1,60 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Compound Interest Calculator";
+const description = "Project how investments grow with compound interest and monthly contributions.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/compound-interest-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">See how your starting balance and recurring deposits compound over time. Adjust the compounding frequency to match your account.</p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="compound-form">
+      <div class="form-grid">
+        <div>
+          <label for="starting-balance">Starting balance</label>
+          <input id="starting-balance" name="principal" type="number" min="0" step="100" placeholder="5000" required />
+        </div>
+        <div>
+          <label for="monthly-contribution">Monthly contribution</label>
+          <input id="monthly-contribution" name="contribution" type="number" min="0" step="50" placeholder="300" />
+        </div>
+        <div>
+          <label for="annual-rate">Annual return (%)</label>
+          <input id="annual-rate" name="rate" type="number" min="0" step="0.1" value="7" required />
+        </div>
+        <div>
+          <label for="years">Years invested</label>
+          <input id="years" name="years" type="number" min="1" step="1" value="20" required />
+        </div>
+        <div>
+          <label for="compounding">Compounding frequency</label>
+          <select id="compounding" name="frequency">
+            <option value="annually">Annually</option>
+            <option value="quarterly">Quarterly</option>
+            <option value="monthly" selected>Monthly</option>
+            <option value="daily">Daily</option>
+          </select>
+        </div>
+        <div>
+          <label for="annual-increase">Annual contribution increase (%)</label>
+          <input id="annual-increase" name="raise" type="number" min="0" step="0.1" value="0" />
+        </div>
+      </div>
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Calculate growth</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">Assumes deposits occur at the end of each month. Contributions can optionally step up each year.</p>
+    </form>
+  </section>
+
+  <section id="compound-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="compound-inline-1" />
+  <script defer src="/js/compound-interest.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/currency-converter.astro
+++ b/src/pages/calculators/currency-converter.astro
@@ -1,0 +1,43 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Currency Converter";
+const description = "Convert between world currencies with live exchange rates.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/currency-converter">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">Pick two currencies and enter an amount. We'll fetch the latest rates (with an offline fallback) and show the converted value instantly.</p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="currency-form">
+      <label for="currency-amount">Amount</label>
+      <input id="currency-amount" name="amount" type="number" min="0" step="0.01" value="1" />
+
+      <div class="form-grid single" style="margin-top:12px;">
+        <div>
+          <label for="currency-from">From</label>
+          <select id="currency-from" name="from"></select>
+        </div>
+        <div>
+          <label for="currency-to">To</label>
+          <select id="currency-to" name="to"></select>
+        </div>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap; align-items:center;">
+        <button class="btn" type="submit">Convert</button>
+        <button class="btn" type="button" id="currency-swap">Swap</button>
+        <span class="helper" id="currency-status">Loading exchange rates…</span>
+      </div>
+    </form>
+  </section>
+
+  <section id="currency-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="currency-inline-1" />
+  <script defer src="/js/currency-converter.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/inflation-calculator.astro
+++ b/src/pages/calculators/inflation-calculator.astro
@@ -1,0 +1,43 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Inflation Calculator";
+const description = "Compare purchasing power across years using U.S. CPI data.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/inflation-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">Find out how prices have changed over time. Enter an amount and pick two years to see the equivalent value after inflation.</p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="inflation-form">
+      <div class="form-grid">
+        <div>
+          <label for="inflation-amount">Amount</label>
+          <input id="inflation-amount" name="amount" type="number" min="0" step="1" value="100" required />
+        </div>
+        <div>
+          <label for="inflation-start">Start year</label>
+          <select id="inflation-start" name="start"></select>
+        </div>
+        <div>
+          <label for="inflation-end">End year</label>
+          <select id="inflation-end" name="end"></select>
+        </div>
+      </div>
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Adjust for inflation</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">Data based on the U.S. Consumer Price Index (CPI-U). The latest year updates each January.</p>
+    </form>
+  </section>
+
+  <section id="inflation-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="inflation-inline-1" />
+  <script defer src="/js/inflation-calculator.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/loan-calculator.astro
+++ b/src/pages/calculators/loan-calculator.astro
@@ -1,0 +1,48 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Loan Calculator";
+const description = "Estimate monthly loan payments with a full principal and interest breakdown.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/loan-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">Plug in a loan amount, interest rate, and term to see your monthly payment plus how much goes toward principal versus interest.</p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="loan-form">
+      <div class="form-grid">
+        <div>
+          <label for="loan-amount">Loan amount</label>
+          <input id="loan-amount" name="amount" type="number" min="0" step="0.01" placeholder="25000" required />
+        </div>
+        <div>
+          <label for="loan-rate">Annual interest rate (%)</label>
+          <input id="loan-rate" name="rate" type="number" min="0" step="0.01" placeholder="6.5" required />
+        </div>
+        <div>
+          <label for="loan-term">Loan term (years)</label>
+          <input id="loan-term" name="term" type="number" min="1" step="1" placeholder="5" required />
+        </div>
+        <div>
+          <label for="loan-extra">Extra monthly payment (optional)</label>
+          <input id="loan-extra" name="extra" type="number" min="0" step="0.01" placeholder="0" />
+        </div>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Calculate payment</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">Payments are calculated using the standard amortizing loan formula. Extra payments are applied directly to principal.</p>
+    </form>
+  </section>
+
+  <section id="loan-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="loan-inline-1" />
+  <script defer src="/js/loan-calculator.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/mortgage-calculator.astro
+++ b/src/pages/calculators/mortgage-calculator.astro
@@ -1,0 +1,77 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Mortgage Calculator";
+const description = "Plan a home purchase with affordability guidance and an amortization schedule.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/mortgage-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">Estimate your monthly mortgage payment, check how much home you can afford, and review a year-by-year payoff schedule.</p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="mortgage-form">
+      <h2 style="margin:0 0 12px; font-size:20px;">Loan basics</h2>
+      <div class="form-grid">
+        <div>
+          <label for="home-price">Home price</label>
+          <input id="home-price" name="price" type="number" min="0" step="1000" placeholder="400000" required />
+        </div>
+        <div>
+          <label for="down-payment">Down payment (%)</label>
+          <input id="down-payment" name="down" type="number" min="0" max="100" step="0.1" value="20" required />
+        </div>
+        <div>
+          <label for="mortgage-rate">Interest rate (%)</label>
+          <input id="mortgage-rate" name="rate" type="number" min="0" step="0.01" value="6.25" required />
+        </div>
+        <div>
+          <label for="mortgage-term">Loan term (years)</label>
+          <input id="mortgage-term" name="term" type="number" min="5" step="5" value="30" required />
+        </div>
+      </div>
+
+      <h2 style="margin:22px 0 12px; font-size:20px;">Monthly cost extras</h2>
+      <div class="form-grid">
+        <div>
+          <label for="property-tax">Property tax rate (% of home value)</label>
+          <input id="property-tax" name="tax" type="number" min="0" step="0.01" value="1.1" />
+        </div>
+        <div>
+          <label for="insurance">Home insurance (per year)</label>
+          <input id="insurance" name="insurance" type="number" min="0" step="50" placeholder="1200" />
+        </div>
+        <div>
+          <label for="hoa">HOA dues (per month)</label>
+          <input id="hoa" name="hoa" type="number" min="0" step="10" placeholder="0" />
+        </div>
+      </div>
+
+      <h2 style="margin:22px 0 12px; font-size:20px;">Affordability check (optional)</h2>
+      <div class="form-grid">
+        <div>
+          <label for="household-income">Household income (per year)</label>
+          <input id="household-income" name="income" type="number" min="0" step="1000" placeholder="95000" />
+        </div>
+        <div>
+          <label for="monthly-debt">Monthly debt payments</label>
+          <input id="monthly-debt" name="debts" type="number" min="0" step="10" placeholder="450" />
+        </div>
+      </div>
+
+      <div style="margin-top:16px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Run mortgage math</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">Affordability uses a 36% debt-to-income guideline. Property taxes and insurance are estimates—adjust with your local data.</p>
+    </form>
+  </section>
+
+  <section id="mortgage-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="mortgage-inline-1" />
+  <script defer src="/js/mortgage-calculator.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/salary-to-hourly.astro
+++ b/src/pages/calculators/salary-to-hourly.astro
@@ -1,0 +1,48 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Salary ↔ Hourly Converter";
+const description = "Quickly convert annual pay to hourly wages (and back again).";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/salary-to-hourly">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">Enter either your yearly salary or hourly wage along with your typical schedule to see the equivalent pay.</p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="salary-form">
+      <div class="form-grid">
+        <div>
+          <label for="annual-salary">Annual salary</label>
+          <input id="annual-salary" name="annual" type="number" min="0" step="1000" placeholder="65000" />
+        </div>
+        <div>
+          <label for="hourly-rate">Hourly rate</label>
+          <input id="hourly-rate" name="hourly" type="number" min="0" step="0.25" placeholder="31.25" />
+        </div>
+        <div>
+          <label for="hours-week">Hours per week</label>
+          <input id="hours-week" name="hours" type="number" min="1" max="80" step="0.5" value="40" required />
+        </div>
+        <div>
+          <label for="weeks-year">Paid weeks per year</label>
+          <input id="weeks-year" name="weeks" type="number" min="1" max="52" step="0.5" value="52" required />
+        </div>
+      </div>
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="button" data-action="annual-to-hourly">Annual → Hourly</button>
+        <button class="btn" type="button" data-action="hourly-to-annual">Hourly → Annual</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">Use the buttons to set the direction of the conversion. Weeks per year exclude unpaid time off.</p>
+    </form>
+  </section>
+
+  <section id="salary-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="salary-inline-1" />
+  <script defer src="/js/salary-hourly.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/savings-goal-calculator.astro
+++ b/src/pages/calculators/savings-goal-calculator.astro
@@ -1,0 +1,47 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Savings Goal Calculator";
+const description = "Figure out the monthly contributions needed to hit a future target.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/savings-goal-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">Set a target amount and timeline. We'll tell you how much to save each month, factoring in optional investment growth.</p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="savings-form">
+      <div class="form-grid">
+        <div>
+          <label for="goal-amount">Goal amount</label>
+          <input id="goal-amount" name="goal" type="number" min="0" step="100" placeholder="25000" required />
+        </div>
+        <div>
+          <label for="current-savings">Current savings</label>
+          <input id="current-savings" name="current" type="number" min="0" step="100" value="0" />
+        </div>
+        <div>
+          <label for="goal-years">Timeframe (years)</label>
+          <input id="goal-years" name="years" type="number" min="0.5" step="0.5" value="5" required />
+        </div>
+        <div>
+          <label for="expected-return">Expected annual return (%)</label>
+          <input id="expected-return" name="rate" type="number" min="0" step="0.1" value="4" />
+        </div>
+      </div>
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Calculate monthly savings</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">Return is optional—set it to 0% for a cash-only plan. We assume monthly deposits at the end of each month.</p>
+    </form>
+  </section>
+
+  <section id="savings-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="savings-inline-1" />
+  <script defer src="/js/savings-goal.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/tip-calculator.astro
+++ b/src/pages/calculators/tip-calculator.astro
@@ -1,0 +1,53 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Tip Calculator";
+const description = "Split restaurant bills with tip suggestions and per-person totals.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/tip-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">Pick a tip percentage, enter the bill, and optionally split the total between friends. We'll show tip amounts instantly.</p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="tip-form">
+      <div class="form-grid columns-3">
+        <div>
+          <label for="bill-amount">Bill amount</label>
+          <input id="bill-amount" name="bill" type="number" min="0" step="0.01" placeholder="85.42" required />
+        </div>
+        <div>
+          <label for="tip-percent">Tip percentage</label>
+          <select id="tip-percent" name="percent">
+            <option value="15">15%</option>
+            <option value="18">18%</option>
+            <option value="20" selected>20%</option>
+            <option value="22">22%</option>
+            <option value="custom">Custom</option>
+          </select>
+        </div>
+        <div id="custom-tip-wrapper" style="display:none;">
+          <label for="custom-tip">Custom tip (%)</label>
+          <input id="custom-tip" name="custom" type="number" min="0" step="0.1" placeholder="25" />
+        </div>
+        <div>
+          <label for="people-count">People splitting</label>
+          <input id="people-count" name="people" type="number" min="1" step="1" value="1" required />
+        </div>
+      </div>
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Calculate tip</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">Need a quick split? Set people to more than one and we'll show per-person totals.</p>
+    </form>
+  </section>
+
+  <section id="tip-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="tip-inline-1" />
+  <script defer src="/js/tip-calculator.js"></script>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,42 +2,101 @@
 import BaseLayout from "@/layouts/BaseLayout.astro";
 ---
 
-<BaseLayout title="Date & Holiday Calculators" description="Quick calculators: days from a date, birthday countdown, and U.S. holiday timers.">
+<BaseLayout
+  title="CalcNest – Date, Money, and Planning Calculators"
+  description="Plan schedules and finances with countdowns, loan tools, currency converters, and more."
+>
   <section class="hero">
-    <h1>Date & Holiday Calculators</h1>
-    <p>Use these quick tools for work, school, or planning. No account required.</p>
+    <h1>Everyday Calculators</h1>
+    <p>Plan timelines, budgets, and goals in one place. All tools run instantly in your browser—no sign-up required.</p>
   </section>
 
-  <section class="grid">
-    <a class="card" href="/calculators/days-from-date">
-      <h3>Days From (or Until) a Date</h3>
-      <p>Find how many days are between any two dates—or from today.</p>
-      <span class="btn">Open</span>
-    </a>
+  <section>
+    <h2 class="section-title">Time &amp; Countdown</h2>
+    <div class="grid">
+      <a class="card" href="/calculators/days-from-date">
+        <h3>Days From (or Until) a Date</h3>
+        <p>Find how many days are between any two dates—or from today.</p>
+        <span class="btn">Open</span>
+      </a>
 
-    <a class="card" href="/calculators/age-calculator">
-      <h3>Age Calculator</h3>
-      <p>Enter a birthdate to see your age in years, months, and days.</p>
-      <span class="btn">Open</span>
-    </a>
+      <a class="card" href="/calculators/age-calculator">
+        <h3>Age Calculator</h3>
+        <p>Enter a birthdate to see your age in years, months, and days.</p>
+        <span class="btn">Open</span>
+      </a>
 
-    <a class="card" href="/calculators/days-until-birthday">
-      <h3>Days Until Your Birthday</h3>
-      <p>Countdown with leap-year handling for Feb 29 birthdays.</p>
-      <span class="btn">Open</span>
-    </a>
+      <a class="card" href="/calculators/days-until-birthday">
+        <h3>Days Until Your Birthday</h3>
+        <p>Countdown with leap-year handling for Feb 29 birthdays.</p>
+        <span class="btn">Open</span>
+      </a>
 
-    <a class="card" href="/calculators/anniversary-countdown">
-      <h3>Anniversary Countdown</h3>
-      <p>Preview the next few anniversaries for any meaningful date.</p>
-      <span class="btn">Open</span>
-    </a>
+      <a class="card" href="/calculators/anniversary-countdown">
+        <h3>Anniversary Countdown</h3>
+        <p>Preview the next few anniversaries for any meaningful date.</p>
+        <span class="btn">Open</span>
+      </a>
 
-    <a class="card" href="/calculators/holiday-countdown">
-      <h3>Holiday Countdown (US)</h3>
-      <p>See days remaining until major U.S. holidays.</p>
-      <span class="btn">Open</span>
-    </a>
+      <a class="card" href="/calculators/holiday-countdown">
+        <h3>Holiday Countdown (US)</h3>
+        <p>See days remaining until major U.S. holidays.</p>
+        <span class="btn">Open</span>
+      </a>
+    </div>
+  </section>
+
+  <section>
+    <h2 class="section-title">Money &amp; Planning</h2>
+    <div class="grid">
+      <a class="card" href="/calculators/loan-calculator">
+        <h3>Loan Calculator</h3>
+        <p>Estimate payments and see principal versus interest by year.</p>
+        <span class="btn">Open</span>
+      </a>
+
+      <a class="card" href="/calculators/mortgage-calculator">
+        <h3>Mortgage Planner</h3>
+        <p>Check affordability, monthly costs, and an amortization schedule.</p>
+        <span class="btn">Open</span>
+      </a>
+
+      <a class="card" href="/calculators/compound-interest-calculator">
+        <h3>Compound Interest</h3>
+        <p>Model investment growth with recurring deposits and raises.</p>
+        <span class="btn">Open</span>
+      </a>
+
+      <a class="card" href="/calculators/currency-converter">
+        <h3>Currency Converter</h3>
+        <p>Convert between 30+ currencies with live-rate fallback support.</p>
+        <span class="btn">Open</span>
+      </a>
+
+      <a class="card" href="/calculators/inflation-calculator">
+        <h3>Inflation Adjuster</h3>
+        <p>Compare the buying power of money across different years.</p>
+        <span class="btn">Open</span>
+      </a>
+
+      <a class="card" href="/calculators/salary-to-hourly">
+        <h3>Salary ↔ Hourly</h3>
+        <p>Convert yearly pay to hourly wages (and vice versa) with your schedule.</p>
+        <span class="btn">Open</span>
+      </a>
+
+      <a class="card" href="/calculators/tip-calculator">
+        <h3>Tip Splitter</h3>
+        <p>Quickly find tip amounts and per-person totals for the table.</p>
+        <span class="btn">Open</span>
+      </a>
+
+      <a class="card" href="/calculators/savings-goal-calculator">
+        <h3>Savings Goal</h3>
+        <p>See the monthly deposit needed to reach a target with growth.</p>
+        <span class="btn">Open</span>
+      </a>
+    </div>
   </section>
 </BaseLayout>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,12 @@
 /* CSS reset (minimal) */
-* { box-sizing: border-box; }
-html, body { margin: 0; padding: 0; }
+* {
+  box-sizing: border-box;
+}
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
 
 /* Theme */
 :root {
@@ -12,35 +18,74 @@ html, body { margin: 0; padding: 0; }
   --muted: #a7b2d9;
   --brand: #4e8cff;
   --accent: #ffd166;
-  --shadow: 0 10px 30px rgba(0,0,0,.35);
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
 }
 
 body {
-  background: radial-gradient(1200px 600px at 20% -10%, #1a2140 0%, #0b0f1a 60%) no-repeat fixed;
+  background: radial-gradient(1200px 600px at 20% -10%, #1a2140 0%, #0b0f1a 60%)
+    no-repeat fixed;
   color: var(--text);
-  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    Segoe UI,
+    Roboto,
+    "Helvetica Neue",
+    Arial,
+    "Noto Sans",
+    "Apple Color Emoji",
+    "Segoe UI Emoji";
   line-height: 1.55;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a { color: var(--brand); text-decoration: none; }
-a:hover { text-decoration: underline; }
+a {
+  color: var(--brand);
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
 
-.container { max-width: 1100px; margin: 0 auto; padding: 24px; }
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px;
+}
 
 /* Header */
 .site-header {
-  position: sticky; top: 0; z-index: 40;
+  position: sticky;
+  top: 0;
+  z-index: 40;
   backdrop-filter: blur(6px);
   background: color-mix(in oklab, var(--panel) 75%, transparent);
   border-bottom: 1px solid var(--border);
 }
-.header-inner { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
-.brand { font-weight: 800; font-size: 20px; letter-spacing: .2px; }
-.nav { display: flex; gap: 14px; flex-wrap: wrap; }
-.nav a { color: var(--muted); }
-.nav a:hover { color: var(--text); }
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+.brand {
+  font-weight: 800;
+  font-size: 20px;
+  letter-spacing: 0.2px;
+}
+.nav {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.nav a {
+  color: var(--muted);
+}
+.nav a:hover {
+  color: var(--text);
+}
 
 /* Footer */
 .site-footer {
@@ -48,24 +93,47 @@ a:hover { text-decoration: underline; }
   border-top: 1px solid var(--border);
   background: var(--panel-2);
 }
-.footer-inner { display: flex; gap: 12px; align-items: center; justify-content: space-between; flex-wrap: wrap; }
+.footer-inner {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
 
 /* UI */
 .hero {
   padding: 28px;
   border-radius: 18px;
-  background: linear-gradient(160deg, rgba(78,140,255,.15), rgba(255,209,102,.08)) , var(--panel);
+  background: linear-gradient(
+      160deg,
+      rgba(78, 140, 255, 0.15),
+      rgba(255, 209, 102, 0.08)
+    ),
+    var(--panel);
   border: 1px solid var(--border);
   box-shadow: var(--shadow);
 }
-.hero h1 { margin: 0 0 8px; font-size: clamp(28px, 3.5vw, 40px); }
-.hero p { margin: 0; color: var(--muted); }
+.hero h1 {
+  margin: 0 0 8px;
+  font-size: clamp(28px, 3.5vw, 40px);
+}
+.hero p {
+  margin: 0;
+  color: var(--muted);
+}
 
 .grid {
-  display: grid; gap: 16px; margin-top: 22px;
+  display: grid;
+  gap: 16px;
+  margin-top: 22px;
   grid-template-columns: 1fr;
 }
-@media (min-width: 720px) { .grid { grid-template-columns: repeat(3, 1fr); } }
+@media (min-width: 720px) {
+  .grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
 
 .card {
   background: var(--panel);
@@ -73,14 +141,29 @@ a:hover { text-decoration: underline; }
   border-radius: 16px;
   padding: 18px;
   box-shadow: var(--shadow);
-  transition: transform .15s ease, border-color .15s ease, box-shadow .15s ease;
+  transition:
+    transform 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
 }
-.card:hover { transform: translateY(-2px); border-color: #2a3865; box-shadow: 0 16px 36px rgba(0,0,0,.45); }
-.card h3 { margin: 0 0 6px; font-size: 18px; }
-.card p { margin: 0 0 12px; color: var(--muted); }
+.card:hover {
+  transform: translateY(-2px);
+  border-color: #2a3865;
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.45);
+}
+.card h3 {
+  margin: 0 0 6px;
+  font-size: 18px;
+}
+.card p {
+  margin: 0 0 12px;
+  color: var(--muted);
+}
 
 .btn {
-  display: inline-flex; align-items: center; justify-content: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 10px 14px;
   border-radius: 12px;
   border: 1px solid #2a3865;
@@ -88,16 +171,31 @@ a:hover { text-decoration: underline; }
   color: var(--text);
   cursor: pointer;
 }
-.btn:hover { background: #2b3c72; }
+.btn:hover {
+  background: #2b3c72;
+}
 
 /* Forms */
-label { display:block; margin: 12px 0 6px; color: var(--muted); }
-input, select {
-  width: 100%; padding: 10px 12px; border-radius: 10px;
-  border: 1px solid var(--border); background:#0d1325; color: var(--text);
+label {
+  display: block;
+  margin: 12px 0 6px;
+  color: var(--muted);
 }
-.date-input { position: relative; }
-.date-input input[data-role="date-text"] { padding-right: 44px; }
+input,
+select {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: #0d1325;
+  color: var(--text);
+}
+.date-input {
+  position: relative;
+}
+.date-input input[data-role="date-text"] {
+  padding-right: 44px;
+}
 .date-trigger {
   position: absolute;
   top: 50%;
@@ -109,7 +207,9 @@ input, select {
   padding: 6px;
   border-radius: 8px;
   cursor: pointer;
-  transition: color .15s ease, background .15s ease;
+  transition:
+    color 0.15s ease,
+    background 0.15s ease;
 }
 .date-trigger:hover,
 .date-trigger:focus-visible {
@@ -117,7 +217,12 @@ input, select {
   background: rgba(78, 140, 255, 0.12);
   outline: none;
 }
-.date-trigger svg { width: 18px; height: 18px; display: block; fill: currentColor; }
+.date-trigger svg {
+  width: 18px;
+  height: 18px;
+  display: block;
+  fill: currentColor;
+}
 .date-picker {
   position: absolute;
   opacity: 0;
@@ -125,7 +230,121 @@ input, select {
   width: 0;
   height: 0;
 }
-.helper { font-size: 13px; color: var(--muted); }
+.helper {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.section-title {
+  margin: 28px 0 12px;
+  font-size: 22px;
+}
+
+.form-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 1fr;
+}
+
+.form-grid.single {
+  grid-template-columns: 1fr;
+}
+
+.form-grid.columns-3 {
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 720px) {
+  .form-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .form-grid.single {
+    grid-template-columns: 1fr;
+  }
+
+  .form-grid.columns-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.stat-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin-top: 14px;
+}
+
+.stat {
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  padding: 12px;
+  border-radius: 12px;
+}
+
+.stat span {
+  display: block;
+}
+
+.stat .label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+
+.stat .value {
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(78, 140, 255, 0.14);
+  font-size: 12px;
+  color: var(--brand);
+}
+
+.table-wrap {
+  margin-top: 16px;
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 420px;
+}
+
+th,
+td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  font-size: 14px;
+}
+
+tbody tr:hover {
+  background: rgba(78, 140, 255, 0.08);
+}
 
 /* Ad placeholder (keep but subtle) */
-.ad { margin-top: 12px; padding: 10px; border:1px dashed var(--border); border-radius: 12px; color: var(--muted); text-align:center; font-size: 13px; }
+.ad {
+  margin-top: 12px;
+  padding: 10px;
+  border: 1px dashed var(--border);
+  border-radius: 12px;
+  color: var(--muted);
+  text-align: center;
+  font-size: 13px;
+}


### PR DESCRIPTION
## Summary
- add loan, mortgage, compound interest, currency, inflation, salary/hourly, tip, and savings goal calculator pages with matching scripts
- expand global styling with stat grids, tables, and form layout helpers and refresh the homepage + navigation to surface the new tools
- introduce live/fallback exchange rates, CPI-based inflation data, and amortization logic for detailed financial outputs

## Testing
- npm run format
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c87929cc4c83238da9e0ff4f070993