### PR TITLE
Organize header navigation into dropdown categories

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,6 +7,43 @@ const {
   pathname = "/",
 } = Astro.props;
 const url = new URL(pathname, Astro.site ?? "http://localhost:4321");
+
+const menuCategories = [
+  {
+    label: "Date & Events",
+    items: [
+      { label: "Days From Date", href: "/calculators/days-from-date" },
+      { label: "Age Calculator", href: "/calculators/age-calculator" },
+      { label: "Birthday Countdown", href: "/calculators/days-until-birthday" },
+      {
+        label: "Anniversary Countdown",
+        href: "/calculators/anniversary-countdown",
+      },
+      { label: "Holiday Countdown", href: "/calculators/holiday-countdown" },
+    ],
+  },
+  {
+    label: "Loans & Interest",
+    items: [
+      { label: "Loan Calculator", href: "/calculators/loan-calculator" },
+      { label: "Mortgage Calculator", href: "/calculators/mortgage-calculator" },
+      {
+        label: "Compound Interest",
+        href: "/calculators/compound-interest-calculator",
+      },
+      { label: "Inflation Calculator", href: "/calculators/inflation-calculator" },
+    ],
+  },
+  {
+    label: "Money & Budgeting",
+    items: [
+      { label: "Currency Converter", href: "/calculators/currency-converter" },
+      { label: "Salary to Hourly", href: "/calculators/salary-to-hourly" },
+      { label: "Tip Calculator", href: "/calculators/tip-calculator" },
+      { label: "Savings Goal", href: "/calculators/savings-goal-calculator" },
+    ],
+  },
+];
 ---
 
 <!DOCTYPE html>
@@ -29,19 +66,23 @@ const url = new URL(pathname, Astro.site ?? "http://localhost:4321");
       <div class="container header-inner">
         <a class="brand" href="/">CalcNest</a>
         <nav class="nav" aria-label="Main">
-          <a href="/calculators/days-from-date">Days From Date</a>
-          <a href="/calculators/age-calculator">Age</a>
-          <a href="/calculators/days-until-birthday">Birthday</a>
-          <a href="/calculators/anniversary-countdown">Anniversary</a>
-          <a href="/calculators/holiday-countdown">Holidays</a>
-          <a href="/calculators/loan-calculator">Loan</a>
-          <a href="/calculators/mortgage-calculator">Mortgage</a>
-          <a href="/calculators/compound-interest-calculator">Invest</a>
-          <a href="/calculators/currency-converter">Currency</a>
-          <a href="/calculators/inflation-calculator">Inflation</a>
-          <a href="/calculators/salary-to-hourly">Salary</a>
-          <a href="/calculators/tip-calculator">Tip</a>
-          <a href="/calculators/savings-goal-calculator">Savings</a>
+          <details class="nav-dropdown">
+            <summary class="nav-trigger" aria-haspopup="true">Calculators</summary>
+            <div class="nav-menu">
+              {menuCategories.map((category) => (
+                <section class="nav-group">
+                  <p class="nav-group-title">{category.label}</p>
+                  <ul>
+                    {category.items.map((item) => (
+                      <li>
+                        <a href={item.href}>{item.label}</a>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          </details>
         </nav>
       </div>
     </header>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -77,13 +77,105 @@ a:hover {
 }
 .nav {
   display: flex;
-  gap: 14px;
-  flex-wrap: wrap;
+  justify-content: flex-end;
 }
-.nav a {
+.nav-dropdown {
+  position: relative;
+}
+.nav-trigger {
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--panel-2);
+  color: var(--text);
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    background 0.2s ease,
+    color 0.2s ease;
+}
+.nav-trigger::-webkit-details-marker {
+  display: none;
+}
+.nav-trigger::after {
+  content: "▾";
+  font-size: 12px;
+  transform: rotate(0deg);
+  transition: transform 0.2s ease;
+}
+.nav-dropdown[open] > .nav-trigger::after {
+  transform: rotate(-180deg);
+}
+.nav-dropdown[open] > .nav-trigger {
+  border-color: var(--brand);
+  background: color-mix(in oklab, var(--panel-2) 85%, black 10%);
+}
+.nav-trigger:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+.nav-menu {
+  position: absolute;
+  inset-inline-end: 0;
+  margin-top: 12px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: var(--shadow);
+  width: min(92vw, 520px);
+  display: grid;
+  gap: 16px;
+  z-index: 20;
+}
+@media (min-width: 640px) {
+  .nav-menu {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+@media (max-width: 639px) {
+  .nav-menu {
+    inset-inline-end: auto;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+}
+.nav-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.nav-group-title {
+  margin: 0;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--muted);
 }
-.nav a:hover {
+.nav-group ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+.nav-group a {
+  color: var(--text);
+  font-weight: 500;
+  padding: 6px 8px;
+  border-radius: 8px;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+.nav-group a:hover,
+.nav-group a:focus-visible {
+  background: #1d2745;
   color: var(--text);
 }
 


### PR DESCRIPTION
## Summary
- replace the long list of header links with a calculators dropdown that groups destinations by category
- add responsive styling for the dropdown menu so it is easy to use on mobile and desktop

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8ab9f667c8323924d4c0ca75cea5d