### PR TITLE
Format currency update time in local timezone

### DIFF
--- a/public/js/currency-converter.js
+++ b/public/js/currency-converter.js
@@ -81,6 +81,29 @@
     source: "offline",
   };
 
+  function formatLocalUpdateTime(utcString) {
+    if (!utcString) return "recently";
+    const parsedDate = new Date(utcString);
+    if (Number.isNaN(parsedDate.getTime())) {
+      return utcString;
+    }
+
+    try {
+      const formatter = new Intl.DateTimeFormat(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short",
+        timeZoneName: "short",
+      });
+      return formatter.format(parsedDate);
+    } catch (error) {
+      const fallbackFormatter = new Intl.DateTimeFormat(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      });
+      return fallbackFormatter.format(parsedDate);
+    }
+  }
+
   function populateSelects() {
     const options = currencies
       .map(
@@ -152,7 +175,9 @@
       }
       rateState.base = data.base_code || "USD";
       rateState.rates = { ...data.rates, [rateState.base]: 1 };
-      rateState.updated = `updated ${data.time_last_update_utc || "recently"}`;
+      rateState.updated = `updated ${formatLocalUpdateTime(
+        data.time_last_update_utc,
+      )}`;
       rateState.source = "live";
       updateStatus(`Live rates ${rateState.updated}`);
     } catch (error) {


### PR DESCRIPTION
## Summary
- format the currency converter's last update timestamp in the visitor's local time zone instead of raw UTC text
- add a resilient formatter fallback when generating the localized timestamp

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8b80731088323986e9f8a5e1b0476