### PR TITLE
Sync header navigation with home page categories

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import "@/styles/global.css";
+import { calculatorCategories } from "@/lib/calculatorData";
 
 const {
   title = "Calculator Hub",
@@ -29,19 +30,22 @@ const url = new URL(pathname, Astro.site ?? "http://localhost:4321");
       <div class="container header-inner">
         <a class="brand" href="/">CalcNest</a>
         <nav class="nav" aria-label="Main">
-          <a href="/calculators/days-from-date">Days From Date</a>
-          <a href="/calculators/age-calculator">Age</a>
-          <a href="/calculators/days-until-birthday">Birthday</a>
-          <a href="/calculators/anniversary-countdown">Anniversary</a>
-          <a href="/calculators/holiday-countdown">Holidays</a>
-          <a href="/calculators/loan-calculator">Loan</a>
-          <a href="/calculators/mortgage-calculator">Mortgage</a>
-          <a href="/calculators/compound-interest-calculator">Invest</a>
-          <a href="/calculators/currency-converter">Currency</a>
-          <a href="/calculators/inflation-calculator">Inflation</a>
-          <a href="/calculators/salary-to-hourly">Salary</a>
-          <a href="/calculators/tip-calculator">Tip</a>
-          <a href="/calculators/savings-goal-calculator">Savings</a>
+          <ul class="nav-list">
+            {calculatorCategories.map((category) => (
+              <li>
+                <details class="nav-category">
+                  <summary>{category.label}</summary>
+                  <div class="nav-panel">
+                    {category.calculators.map((calculator) => (
+                      <a class="nav-item" href={calculator.href}>
+                        {calculator.navLabel}
+                      </a>
+                    ))}
+                  </div>
+                </details>
+              </li>
+            ))}
+          </ul>
         </nav>
       </div>
     </header>

--- a/src/lib/calculatorData.ts
+++ b/src/lib/calculatorData.ts
@@ -1,0 +1,105 @@
+export interface CalculatorInfo {
+  href: string;
+  name: string;
+  navLabel: string;
+  description: string;
+}
+
+export interface CalculatorCategory {
+  id: string;
+  label: string;
+  calculators: CalculatorInfo[];
+}
+
+export const calculatorCategories: CalculatorCategory[] = [
+  {
+    id: "time",
+    label: "Time & Countdown",
+    calculators: [
+      {
+        href: "/calculators/days-from-date",
+        name: "Days From (or Until) a Date",
+        navLabel: "Days From Date",
+        description: "Find how many days are between any two dates—or from today.",
+      },
+      {
+        href: "/calculators/age-calculator",
+        name: "Age Calculator",
+        navLabel: "Age",
+        description: "Enter a birthdate to see your age in years, months, and days.",
+      },
+      {
+        href: "/calculators/days-until-birthday",
+        name: "Days Until Your Birthday",
+        navLabel: "Birthday",
+        description: "Countdown with leap-year handling for Feb 29 birthdays.",
+      },
+      {
+        href: "/calculators/anniversary-countdown",
+        name: "Anniversary Countdown",
+        navLabel: "Anniversary",
+        description: "Preview the next few anniversaries for any meaningful date.",
+      },
+      {
+        href: "/calculators/holiday-countdown",
+        name: "Holiday Countdown (US)",
+        navLabel: "Holidays",
+        description: "See days remaining until major U.S. holidays.",
+      },
+    ],
+  },
+  {
+    id: "money",
+    label: "Money & Planning",
+    calculators: [
+      {
+        href: "/calculators/loan-calculator",
+        name: "Loan Calculator",
+        navLabel: "Loan",
+        description: "Estimate payments and see principal versus interest by year.",
+      },
+      {
+        href: "/calculators/mortgage-calculator",
+        name: "Mortgage Planner",
+        navLabel: "Mortgage",
+        description: "Check affordability, monthly costs, and an amortization schedule.",
+      },
+      {
+        href: "/calculators/compound-interest-calculator",
+        name: "Compound Interest",
+        navLabel: "Invest",
+        description: "Model investment growth with recurring deposits and raises.",
+      },
+      {
+        href: "/calculators/currency-converter",
+        name: "Currency Converter",
+        navLabel: "Currency",
+        description: "Convert between 30+ currencies with live-rate fallback support.",
+      },
+      {
+        href: "/calculators/inflation-calculator",
+        name: "Inflation Adjuster",
+        navLabel: "Inflation",
+        description: "Compare the buying power of money across different years.",
+      },
+      {
+        href: "/calculators/salary-to-hourly",
+        name: "Salary ↔ Hourly",
+        navLabel: "Salary",
+        description: "Convert yearly pay to hourly wages (and vice versa) with your schedule.",
+      },
+      {
+        href: "/calculators/tip-calculator",
+        name: "Tip Splitter",
+        navLabel: "Tip",
+        description: "Quickly find tip amounts and per-person totals for the table.",
+      },
+      {
+        href: "/calculators/savings-goal-calculator",
+        name: "Savings Goal",
+        navLabel: "Savings",
+        description: "See the monthly deposit needed to reach a target with growth.",
+      },
+    ],
+  },
+];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
+import { calculatorCategories } from "@/lib/calculatorData";
 ---
 
 <BaseLayout
@@ -11,92 +12,19 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
     <p>Plan timelines, budgets, and goals in one place. All tools run instantly in your browser—no sign-up required.</p>
   </section>
 
-  <section>
-    <h2 class="section-title">Time &amp; Countdown</h2>
-    <div class="grid">
-      <a class="card" href="/calculators/days-from-date">
-        <h3>Days From (or Until) a Date</h3>
-        <p>Find how many days are between any two dates—or from today.</p>
-        <span class="btn">Open</span>
-      </a>
-
-      <a class="card" href="/calculators/age-calculator">
-        <h3>Age Calculator</h3>
-        <p>Enter a birthdate to see your age in years, months, and days.</p>
-        <span class="btn">Open</span>
-      </a>
-
-      <a class="card" href="/calculators/days-until-birthday">
-        <h3>Days Until Your Birthday</h3>
-        <p>Countdown with leap-year handling for Feb 29 birthdays.</p>
-        <span class="btn">Open</span>
-      </a>
-
-      <a class="card" href="/calculators/anniversary-countdown">
-        <h3>Anniversary Countdown</h3>
-        <p>Preview the next few anniversaries for any meaningful date.</p>
-        <span class="btn">Open</span>
-      </a>
-
-      <a class="card" href="/calculators/holiday-countdown">
-        <h3>Holiday Countdown (US)</h3>
-        <p>See days remaining until major U.S. holidays.</p>
-        <span class="btn">Open</span>
-      </a>
-    </div>
-  </section>
-
-  <section>
-    <h2 class="section-title">Money &amp; Planning</h2>
-    <div class="grid">
-      <a class="card" href="/calculators/loan-calculator">
-        <h3>Loan Calculator</h3>
-        <p>Estimate payments and see principal versus interest by year.</p>
-        <span class="btn">Open</span>
-      </a>
-
-      <a class="card" href="/calculators/mortgage-calculator">
-        <h3>Mortgage Planner</h3>
-        <p>Check affordability, monthly costs, and an amortization schedule.</p>
-        <span class="btn">Open</span>
-      </a>
-
-      <a class="card" href="/calculators/compound-interest-calculator">
-        <h3>Compound Interest</h3>
-        <p>Model investment growth with recurring deposits and raises.</p>
-        <span class="btn">Open</span>
-      </a>
-
-      <a class="card" href="/calculators/currency-converter">
-        <h3>Currency Converter</h3>
-        <p>Convert between 30+ currencies with live-rate fallback support.</p>
-        <span class="btn">Open</span>
-      </a>
-
-      <a class="card" href="/calculators/inflation-calculator">
-        <h3>Inflation Adjuster</h3>
-        <p>Compare the buying power of money across different years.</p>
-        <span class="btn">Open</span>
-      </a>
-
-      <a class="card" href="/calculators/salary-to-hourly">
-        <h3>Salary ↔ Hourly</h3>
-        <p>Convert yearly pay to hourly wages (and vice versa) with your schedule.</p>
-        <span class="btn">Open</span>
-      </a>
-
-      <a class="card" href="/calculators/tip-calculator">
-        <h3>Tip Splitter</h3>
-        <p>Quickly find tip amounts and per-person totals for the table.</p>
-        <span class="btn">Open</span>
-      </a>
-
-      <a class="card" href="/calculators/savings-goal-calculator">
-        <h3>Savings Goal</h3>
-        <p>See the monthly deposit needed to reach a target with growth.</p>
-        <span class="btn">Open</span>
-      </a>
-    </div>
-  </section>
+  {calculatorCategories.map((category) => (
+    <section>
+      <h2 class="section-title">{category.label}</h2>
+      <div class="grid">
+        {category.calculators.map((calculator) => (
+          <a class="card" href={calculator.href}>
+            <h3>{calculator.name}</h3>
+            <p>{calculator.description}</p>
+            <span class="btn">Open</span>
+          </a>
+        ))}
+      </div>
+    </section>
+  ))}
 </BaseLayout>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -76,15 +76,105 @@ a:hover {
   letter-spacing: 0.2px;
 }
 .nav {
+  margin-left: auto;
+}
+
+.nav-list {
   display: flex;
-  gap: 14px;
-  flex-wrap: wrap;
+  align-items: center;
+  gap: 18px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
 }
-.nav a {
+
+.nav-category {
+  position: relative;
+}
+
+.nav-category > summary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  cursor: pointer;
   color: var(--muted);
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  transition:
+    color 0.15s ease,
+    background 0.15s ease,
+    border-color 0.15s ease;
+  border: 1px solid transparent;
 }
-.nav a:hover {
+
+.nav-category > summary::-webkit-details-marker {
+  display: none;
+}
+
+.nav-category > summary::after {
+  content: "";
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid currentColor;
+  transform: translateY(1px);
+}
+
+.nav-category:hover > summary,
+.nav-category[open] > summary,
+.nav-category > summary:focus-visible {
   color: var(--text);
+  background: rgba(78, 140, 255, 0.12);
+  border-color: rgba(78, 140, 255, 0.25);
+  outline: none;
+}
+
+.nav-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  display: none;
+  min-width: 190px;
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: var(--panel-2);
+  box-shadow: var(--shadow);
+  flex-direction: column;
+  gap: 6px;
+  z-index: 10;
+}
+
+.nav-category[open] > .nav-panel {
+  display: flex;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .nav-category:hover > .nav-panel {
+    display: flex;
+  }
+}
+
+.nav-item {
+  display: block;
+  padding: 8px 10px;
+  border-radius: 10px;
+  color: var(--muted);
+  transition:
+    color 0.15s ease,
+    background 0.15s ease;
+}
+
+.nav-item:hover,
+.nav-item:focus-visible {
+  color: var(--text);
+  background: rgba(78, 140, 255, 0.12);
+  text-decoration: none;
+  outline: none;
 }
 
 /* Footer */
@@ -99,6 +189,49 @@ a:hover {
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
+}
+
+@media (max-width: 720px) {
+  .header-inner {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
+  .nav {
+    width: 100%;
+  }
+
+  .nav-list {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .nav-category {
+    width: 100%;
+  }
+
+  .nav-category > summary {
+    width: 100%;
+    padding: 12px 16px;
+    border-radius: 14px;
+    border: 1px solid var(--border);
+    background: var(--panel-2);
+  }
+
+  .nav-category > summary::after {
+    margin-left: auto;
+  }
+
+  .nav-panel {
+    position: static;
+    margin-top: 10px;
+    padding: 12px;
+    border-radius: 12px;
+    background: var(--panel);
+    gap: 8px;
+  }
 }
 
 /* UI */


### PR DESCRIPTION
## Summary
- centralize calculator metadata in a shared data module so category listings stay in sync
- update the header navigation to surface category dropdowns on desktop and stacked accordions on mobile
- render the home page category sections from the shared dataset for automatic updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8c4e7464c8323aba3800817a6827c