### PR TITLE
Add converters for units, time zones, cooking, fuel, speed, and apparel

### DIFF
--- a/public/js/clothing-size-converter.js
+++ b/public/js/clothing-size-converter.js
@@ -1,0 +1,233 @@
+(function () {
+  const form = document.getElementById("clothing-form");
+  const profileSelect = document.getElementById("clothing-profile");
+  const sourceSelect = document.getElementById("clothing-source");
+  const sizeSelect = document.getElementById("clothing-size");
+  const resultEl = document.getElementById("clothing-result");
+
+  if (!form || !profileSelect || !sourceSelect || !sizeSelect || !resultEl) {
+    return;
+  }
+
+  const clothingData = {
+    women: [
+      {
+        intl: "XS",
+        us: "0-2",
+        uk: "4-6",
+        eu: "32-34",
+        bust: "31-33 in / 79-84 cm",
+        waist: "24-26 in / 61-66 cm",
+      },
+      {
+        intl: "S",
+        us: "4-6",
+        uk: "8-10",
+        eu: "36-38",
+        bust: "33-35 in / 84-89 cm",
+        waist: "26-28 in / 66-71 cm",
+      },
+      {
+        intl: "M",
+        us: "8-10",
+        uk: "12-14",
+        eu: "40-42",
+        bust: "36-38 in / 91-97 cm",
+        waist: "29-31 in / 74-79 cm",
+      },
+      {
+        intl: "L",
+        us: "12-14",
+        uk: "16-18",
+        eu: "44-46",
+        bust: "39-41 in / 99-104 cm",
+        waist: "32-34 in / 81-86 cm",
+      },
+      {
+        intl: "XL",
+        us: "16-18",
+        uk: "20-22",
+        eu: "48-50",
+        bust: "42-44 in / 107-112 cm",
+        waist: "35-38 in / 89-97 cm",
+      },
+      {
+        intl: "XXL",
+        us: "20-22",
+        uk: "24-26",
+        eu: "52-54",
+        bust: "45-47 in / 114-119 cm",
+        waist: "39-42 in / 99-107 cm",
+      },
+    ],
+    men: [
+      {
+        intl: "XS",
+        us: "34",
+        uk: "34",
+        eu: "44",
+        chest: "34-36 in / 86-91 cm",
+        waist: "28-30 in / 71-76 cm",
+      },
+      {
+        intl: "S",
+        us: "36",
+        uk: "36",
+        eu: "46",
+        chest: "36-38 in / 91-97 cm",
+        waist: "30-32 in / 76-81 cm",
+      },
+      {
+        intl: "M",
+        us: "38-40",
+        uk: "38-40",
+        eu: "48-50",
+        chest: "38-40 in / 97-102 cm",
+        waist: "32-34 in / 81-86 cm",
+      },
+      {
+        intl: "L",
+        us: "42-44",
+        uk: "42-44",
+        eu: "52-54",
+        chest: "42-44 in / 107-112 cm",
+        waist: "36-38 in / 91-97 cm",
+      },
+      {
+        intl: "XL",
+        us: "46-48",
+        uk: "46-48",
+        eu: "56-58",
+        chest: "46-48 in / 117-122 cm",
+        waist: "40-42 in / 102-107 cm",
+      },
+      {
+        intl: "XXL",
+        us: "50-52",
+        uk: "50-52",
+        eu: "60-62",
+        chest: "50-52 in / 127-132 cm",
+        waist: "44-46 in / 112-117 cm",
+      },
+    ],
+  };
+
+  function populateSizeOptions() {
+    const profile = profileSelect.value;
+    const source = sourceSelect.value;
+    const data = clothingData[profile];
+    const previous = sizeSelect.value;
+
+    sizeSelect.innerHTML = "";
+
+    if (!data) {
+      return;
+    }
+
+    data.forEach((entry, index) => {
+      const sourceValue = entry[source];
+      if (typeof sourceValue === "undefined") {
+        return;
+      }
+      const option = document.createElement("option");
+      option.value = String(index);
+      option.textContent = `${source.toUpperCase()} ${sourceValue}`;
+      sizeSelect.appendChild(option);
+    });
+
+    if (sizeSelect.options.length === 0) {
+      return;
+    }
+
+    if (
+      previous &&
+      Array.from(sizeSelect.options).some((option) => option.value === previous)
+    ) {
+      sizeSelect.value = previous;
+    } else {
+      sizeSelect.selectedIndex = Math.floor(sizeSelect.options.length / 2);
+    }
+  }
+
+  function render() {
+    const profile = profileSelect.value;
+    const source = sourceSelect.value;
+    const index = Number.parseInt(sizeSelect.value, 10);
+    const data = clothingData[profile];
+
+    if (!data || Number.isNaN(index) || !data[index]) {
+      resultEl.innerHTML = `<section class="card"><p>Select a size to see international matches.</p></section>`;
+      return;
+    }
+
+    const entry = data[index];
+    const profileLabel =
+      profileSelect.options[profileSelect.selectedIndex]?.textContent ??
+      "Clothing size";
+    const sourceLabel =
+      sourceSelect.options[sourceSelect.selectedIndex]?.textContent ??
+      source.toUpperCase();
+    const sourceValue = entry[source];
+
+    const rows = [
+      `<tr><th scope="row">International</th><td>${entry.intl}</td></tr>`,
+      `<tr><th scope="row">US</th><td>${entry.us}</td></tr>`,
+      `<tr><th scope="row">UK</th><td>${entry.uk}</td></tr>`,
+      `<tr><th scope="row">EU</th><td>${entry.eu}</td></tr>`,
+    ];
+
+    if (entry.bust) {
+      rows.push(`<tr><th scope="row">Bust</th><td>${entry.bust}</td></tr>`);
+    }
+
+    if (entry.chest) {
+      rows.push(`<tr><th scope="row">Chest</th><td>${entry.chest}</td></tr>`);
+    }
+
+    if (entry.waist) {
+      rows.push(`<tr><th scope="row">Waist</th><td>${entry.waist}</td></tr>`);
+    }
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">${profileLabel}</h2>
+        <p class="helper" style="margin-top:6px;">Selected ${sourceLabel}: ${sourceValue}</p>
+        <div class="table-wrap" style="margin-top:12px;">
+          <table>
+            <tbody>${rows.join("")}</tbody>
+          </table>
+        </div>
+        <p class="helper" style="margin-top:12px;">Sizing varies by brand—use this chart as a starting point and confirm with retailer measurements when possible.</p>
+      </section>
+    `;
+  }
+
+  populateSizeOptions();
+  render();
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    render();
+  });
+
+  form.addEventListener("reset", () => {
+    window.setTimeout(() => {
+      profileSelect.value = "women";
+      sourceSelect.value = "intl";
+      populateSizeOptions();
+      render();
+    }, 0);
+  });
+
+  profileSelect.addEventListener("change", () => {
+    populateSizeOptions();
+    render();
+  });
+
+  sourceSelect.addEventListener("change", () => {
+    populateSizeOptions();
+    render();
+  });
+
+  sizeSelect.addEventListener("change", render);
+})();

--- a/public/js/cooking-converter.js
+++ b/public/js/cooking-converter.js
@@ -1,0 +1,123 @@
+(function () {
+  const form = document.getElementById("cooking-form");
+  const amountInput = document.getElementById("cooking-amount");
+  const fromSelect = document.getElementById("cooking-from");
+  const toSelect = document.getElementById("cooking-to");
+  const resultEl = document.getElementById("cooking-result");
+
+  if (!form || !amountInput || !fromSelect || !toSelect || !resultEl) {
+    return;
+  }
+
+  const units = [
+    { id: "cup", label: "Cups (US)", factor: 236.5882365 },
+    { id: "metricCup", label: "Metric cups", factor: 250 },
+    { id: "tablespoon", label: "Tablespoons (Tbsp)", factor: 14.78676478125 },
+    { id: "teaspoon", label: "Teaspoons (tsp)", factor: 4.92892159375 },
+    { id: "fluidOunce", label: "Fluid ounces (fl oz)", factor: 29.5735295625 },
+    { id: "milliliter", label: "Milliliters (mL)", factor: 1 },
+    { id: "liter", label: "Liters (L)", factor: 1000 },
+    { id: "gram", label: "Grams (g)", factor: 1 },
+    { id: "kilogram", label: "Kilograms (kg)", factor: 1000 },
+    { id: "ounce", label: "Ounces (oz)", factor: 28.349523125 },
+    { id: "pound", label: "Pounds (lb)", factor: 453.59237 },
+  ];
+
+  const unitLookup = units.reduce((acc, unit) => {
+    acc[unit.id] = unit;
+    return acc;
+  }, {});
+
+  function populateSelect(select) {
+    select.innerHTML = "";
+    units.forEach((unit) => {
+      const option = document.createElement("option");
+      option.value = unit.id;
+      option.textContent = unit.label;
+      select.appendChild(option);
+    });
+  }
+
+  function formatValue(value) {
+    if (!Number.isFinite(value)) {
+      return "-";
+    }
+    const abs = Math.abs(value);
+    let maximumFractionDigits = 4;
+    if (abs >= 1000) {
+      maximumFractionDigits = 2;
+    } else if (abs < 1) {
+      maximumFractionDigits = 6;
+    }
+    return value.toLocaleString(undefined, {
+      maximumFractionDigits,
+      minimumFractionDigits: 0,
+    });
+  }
+
+  function convert() {
+    const amount = Number.parseFloat(amountInput.value);
+    const fromUnit = unitLookup[fromSelect.value];
+    const toUnit = unitLookup[toSelect.value];
+
+    if (!Number.isFinite(amount)) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a valid quantity to convert.</p></section>`;
+      return;
+    }
+
+    if (!fromUnit || !toUnit) {
+      resultEl.innerHTML = `<section class="card"><p>Select both a source and target unit.</p></section>`;
+      return;
+    }
+
+    const baseValue = amount * fromUnit.factor;
+    const converted = baseValue / toUnit.factor;
+
+    const rows = units
+      .map((unit) => {
+        const value = baseValue / unit.factor;
+        return `<tr><th scope="row">${unit.label}</th><td>${formatValue(value)}</td></tr>`;
+      })
+      .join("");
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">${formatValue(amount)} ${fromUnit.label} = ${formatValue(converted)} ${toUnit.label}</h2>
+        <div class="table-wrap" style="margin-top:12px;">
+          <table>
+            <thead>
+              <tr><th scope="col">Unit</th><th scope="col">Amount</th></tr>
+            </thead>
+            <tbody>${rows}</tbody>
+          </table>
+        </div>
+        <p class="helper" style="margin-top:12px;">Assumes water density for volume ↔ weight conversions. Adjust for specific ingredients as needed.</p>
+      </section>
+    `;
+  }
+
+  populateSelect(fromSelect);
+  populateSelect(toSelect);
+  const defaultToIndex = units.findIndex((unit) => unit.id === "tablespoon");
+  toSelect.selectedIndex = defaultToIndex >= 0 ? defaultToIndex : 1;
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    convert();
+  });
+
+  form.addEventListener("reset", () => {
+    window.setTimeout(() => {
+      amountInput.value = "1";
+      fromSelect.selectedIndex = 0;
+      toSelect.selectedIndex = defaultToIndex >= 0 ? defaultToIndex : 1;
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+
+  amountInput.addEventListener("input", convert);
+  fromSelect.addEventListener("change", convert);
+  toSelect.addEventListener("change", convert);
+
+  convert();
+})();

--- a/public/js/fuel-economy.js
+++ b/public/js/fuel-economy.js
@@ -1,0 +1,102 @@
+(function () {
+  const form = document.getElementById("fuel-form");
+  const valueInput = document.getElementById("fuel-value");
+  const resultEl = document.getElementById("fuel-result");
+
+  if (!form || !valueInput || !resultEl) {
+    return;
+  }
+
+  const CONVERSION = 235.214583;
+
+  function getDirection() {
+    const checked = form.querySelector('input[name="fuel-direction"]:checked');
+    return checked ? checked.value : "mpg-to-l";
+  }
+
+  function formatValue(value) {
+    if (!Number.isFinite(value)) {
+      return "-";
+    }
+
+    const abs = Math.abs(value);
+    let maximumFractionDigits = 2;
+
+    if (abs >= 100) {
+      maximumFractionDigits = 1;
+    } else if (abs < 1) {
+      maximumFractionDigits = 3;
+    }
+
+    return value.toLocaleString(undefined, {
+      maximumFractionDigits,
+      minimumFractionDigits: 0,
+    });
+  }
+
+  function convert() {
+    const direction = getDirection();
+    const inputValue = Number.parseFloat(valueInput.value);
+
+    if (!Number.isFinite(inputValue) || inputValue <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a positive efficiency value to convert.</p></section>`;
+      return;
+    }
+
+    const mpg = direction === "mpg-to-l" ? inputValue : CONVERSION / inputValue;
+    const lPer100 =
+      direction === "mpg-to-l" ? CONVERSION / inputValue : inputValue;
+
+    const kmPerLiter = 100 / lPer100;
+    const milesPerLiter = kmPerLiter / 1.609344;
+    const gallonsPer100Miles = 100 / mpg;
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">${formatValue(mpg)} mpg ↔ ${formatValue(lPer100)} L/100 km</h2>
+        <div class="stat-grid">
+          <div class="stat"><span class="label">US miles per gallon</span><span class="value">${formatValue(mpg)}</span></div>
+          <div class="stat"><span class="label">Liters per 100 km</span><span class="value">${formatValue(lPer100)}</span></div>
+          <div class="stat"><span class="label">Kilometers per liter</span><span class="value">${formatValue(kmPerLiter)}</span></div>
+          <div class="stat"><span class="label">Miles per liter</span><span class="value">${formatValue(milesPerLiter)}</span></div>
+          <div class="stat"><span class="label">Gallons per 100 miles</span><span class="value">${formatValue(gallonsPer100Miles)}</span></div>
+        </div>
+        <p class="helper" style="margin-top:12px;">Uses the standard 235.2146 constant for converting US MPG to metric efficiency.</p>
+      </section>
+    `;
+  }
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    convert();
+  });
+
+  form.addEventListener("reset", () => {
+    window.setTimeout(() => {
+      resultEl.innerHTML = "";
+      valueInput.value = "";
+      const defaultRadio = form.querySelector(
+        'input[name="fuel-direction"][value="mpg-to-l"]',
+      );
+      if (defaultRadio) {
+        defaultRadio.checked = true;
+      }
+    }, 0);
+  });
+
+  valueInput.addEventListener("input", () => {
+    if (valueInput.value !== "") {
+      convert();
+    } else {
+      resultEl.innerHTML = "";
+    }
+  });
+
+  form.querySelectorAll('input[name="fuel-direction"]').forEach((radio) => {
+    radio.addEventListener("change", () => {
+      if (valueInput.value !== "") {
+        convert();
+      }
+    });
+  });
+})();

--- a/public/js/shoe-size-converter.js
+++ b/public/js/shoe-size-converter.js
@@ -1,0 +1,162 @@
+(function () {
+  const form = document.getElementById("shoe-form");
+  const profileSelect = document.getElementById("shoe-profile");
+  const sourceSelect = document.getElementById("shoe-source");
+  const sizeSelect = document.getElementById("shoe-size");
+  const resultEl = document.getElementById("shoe-result");
+
+  if (!form || !profileSelect || !sourceSelect || !sizeSelect || !resultEl) {
+    return;
+  }
+
+  const shoeData = {
+    women: [
+      { us: 5, uk: 3, eu: 35.5, cm: 21.6 },
+      { us: 5.5, uk: 3.5, eu: 36, cm: 22.2 },
+      { us: 6, uk: 4, eu: 36.5, cm: 22.5 },
+      { us: 6.5, uk: 4.5, eu: 37, cm: 23 },
+      { us: 7, uk: 5, eu: 37.5, cm: 23.5 },
+      { us: 7.5, uk: 5.5, eu: 38, cm: 24 },
+      { us: 8, uk: 6, eu: 38.5, cm: 24.5 },
+      { us: 8.5, uk: 6.5, eu: 39, cm: 24.9 },
+      { us: 9, uk: 7, eu: 40, cm: 25.4 },
+      { us: 9.5, uk: 7.5, eu: 40.5, cm: 25.7 },
+      { us: 10, uk: 8, eu: 41, cm: 26 },
+      { us: 10.5, uk: 8.5, eu: 41.5, cm: 26.4 },
+      { us: 11, uk: 9, eu: 42, cm: 26.8 },
+    ],
+    men: [
+      { us: 6, uk: 5.5, eu: 38.5, cm: 24.1 },
+      { us: 6.5, uk: 6, eu: 39, cm: 24.5 },
+      { us: 7, uk: 6.5, eu: 40, cm: 24.9 },
+      { us: 7.5, uk: 7, eu: 40.5, cm: 25.4 },
+      { us: 8, uk: 7.5, eu: 41, cm: 25.8 },
+      { us: 8.5, uk: 8, eu: 42, cm: 26.2 },
+      { us: 9, uk: 8.5, eu: 42.5, cm: 26.7 },
+      { us: 9.5, uk: 9, eu: 43, cm: 27.1 },
+      { us: 10, uk: 9.5, eu: 44, cm: 27.5 },
+      { us: 10.5, uk: 10, eu: 44.5, cm: 27.9 },
+      { us: 11, uk: 10.5, eu: 45, cm: 28.3 },
+      { us: 11.5, uk: 11, eu: 45.5, cm: 28.7 },
+      { us: 12, uk: 11.5, eu: 46, cm: 29.1 },
+      { us: 13, uk: 12.5, eu: 47.5, cm: 30 },
+    ],
+  };
+
+  function formatSize(value) {
+    if (Number.isInteger(value)) {
+      return value.toString();
+    }
+    return Number.parseFloat(value.toFixed(1)).toString();
+  }
+
+  function formatLength(value) {
+    return value.toFixed(1);
+  }
+
+  function populateSizeOptions() {
+    const profile = profileSelect.value;
+    const source = sourceSelect.value;
+    const data = shoeData[profile];
+    const previous = sizeSelect.value;
+
+    sizeSelect.innerHTML = "";
+
+    if (!data) {
+      return;
+    }
+
+    data.forEach((entry, index) => {
+      const sourceValue = entry[source];
+      if (typeof sourceValue === "undefined") {
+        return;
+      }
+      const option = document.createElement("option");
+      option.value = String(index);
+      option.textContent = `${source.toUpperCase()} ${formatSize(sourceValue)}`;
+      sizeSelect.appendChild(option);
+    });
+
+    if (sizeSelect.options.length === 0) {
+      return;
+    }
+
+    if (
+      previous &&
+      Array.from(sizeSelect.options).some((option) => option.value === previous)
+    ) {
+      sizeSelect.value = previous;
+    } else {
+      sizeSelect.selectedIndex = Math.floor(sizeSelect.options.length / 2);
+    }
+  }
+
+  function render() {
+    const profile = profileSelect.value;
+    const source = sourceSelect.value;
+    const index = Number.parseInt(sizeSelect.value, 10);
+    const data = shoeData[profile];
+
+    if (!data || Number.isNaN(index) || !data[index]) {
+      resultEl.innerHTML = `<section class="card"><p>Select a size to see conversions.</p></section>`;
+      return;
+    }
+
+    const entry = data[index];
+    const profileLabel =
+      profileSelect.options[profileSelect.selectedIndex]?.textContent ??
+      "Shoe size";
+    const sourceLabel =
+      sourceSelect.options[sourceSelect.selectedIndex]?.textContent ??
+      source.toUpperCase();
+    const sourceValue = entry[source];
+    const inches = entry.cm / 2.54;
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">${profileLabel}</h2>
+        <p class="helper" style="margin-top:6px;">Selected ${sourceLabel}: ${formatSize(sourceValue)}</p>
+        <div class="table-wrap" style="margin-top:12px;">
+          <table>
+            <tbody>
+              <tr><th scope="row">US</th><td>${formatSize(entry.us)}</td></tr>
+              <tr><th scope="row">UK</th><td>${formatSize(entry.uk)}</td></tr>
+              <tr><th scope="row">EU</th><td>${formatSize(entry.eu)}</td></tr>
+              <tr><th scope="row">Foot length</th><td>${formatLength(entry.cm)} cm / ${formatLength(inches)} in</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="helper" style="margin-top:12px;">Numbers reflect common conversion charts—brands may vary slightly.</p>
+      </section>
+    `;
+  }
+
+  populateSizeOptions();
+  render();
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    render();
+  });
+
+  form.addEventListener("reset", () => {
+    window.setTimeout(() => {
+      profileSelect.value = "women";
+      sourceSelect.value = "us";
+      populateSizeOptions();
+      render();
+    }, 0);
+  });
+
+  profileSelect.addEventListener("change", () => {
+    populateSizeOptions();
+    render();
+  });
+
+  sourceSelect.addEventListener("change", () => {
+    populateSizeOptions();
+    render();
+  });
+
+  sizeSelect.addEventListener("change", render);
+})();

--- a/public/js/speed-converter.js
+++ b/public/js/speed-converter.js
@@ -1,0 +1,100 @@
+(function () {
+  const form = document.getElementById("speed-form");
+  const valueInput = document.getElementById("speed-value");
+  const resultEl = document.getElementById("speed-result");
+
+  if (!form || !valueInput || !resultEl) {
+    return;
+  }
+
+  const MPH_TO_KMH = 1.609344;
+  const MPH_TO_FTPS = 1.46666667;
+
+  function getDirection() {
+    const checked = form.querySelector('input[name="speed-direction"]:checked');
+    return checked ? checked.value : "mph-to-kmh";
+  }
+
+  function formatValue(value) {
+    if (!Number.isFinite(value)) {
+      return "-";
+    }
+
+    const abs = Math.abs(value);
+    let maximumFractionDigits = 2;
+    if (abs >= 200) {
+      maximumFractionDigits = 1;
+    } else if (abs < 1) {
+      maximumFractionDigits = 3;
+    }
+
+    return value.toLocaleString(undefined, {
+      maximumFractionDigits,
+      minimumFractionDigits: 0,
+    });
+  }
+
+  function convert() {
+    const direction = getDirection();
+    const inputValue = Number.parseFloat(valueInput.value);
+
+    if (!Number.isFinite(inputValue) || inputValue < 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a non-negative speed to convert.</p></section>`;
+      return;
+    }
+
+    const mph =
+      direction === "mph-to-kmh" ? inputValue : inputValue / MPH_TO_KMH;
+    const kmh =
+      direction === "mph-to-kmh" ? inputValue * MPH_TO_KMH : inputValue;
+    const metersPerSecond = kmh / 3.6;
+    const feetPerSecond = mph * MPH_TO_FTPS;
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">${formatValue(mph)} mph ↔ ${formatValue(kmh)} km/h</h2>
+        <div class="stat-grid">
+          <div class="stat"><span class="label">Miles per hour</span><span class="value">${formatValue(mph)}</span></div>
+          <div class="stat"><span class="label">Kilometers per hour</span><span class="value">${formatValue(kmh)}</span></div>
+          <div class="stat"><span class="label">Meters per second</span><span class="value">${formatValue(metersPerSecond)}</span></div>
+          <div class="stat"><span class="label">Feet per second</span><span class="value">${formatValue(feetPerSecond)}</span></div>
+        </div>
+        <p class="helper" style="margin-top:12px;">Uses the exact 1 mile = 1.609344 km conversion.</p>
+      </section>
+    `;
+  }
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    convert();
+  });
+
+  form.addEventListener("reset", () => {
+    window.setTimeout(() => {
+      resultEl.innerHTML = "";
+      valueInput.value = "";
+      const defaultRadio = form.querySelector(
+        'input[name="speed-direction"][value="mph-to-kmh"]',
+      );
+      if (defaultRadio) {
+        defaultRadio.checked = true;
+      }
+    }, 0);
+  });
+
+  valueInput.addEventListener("input", () => {
+    if (valueInput.value !== "") {
+      convert();
+    } else {
+      resultEl.innerHTML = "";
+    }
+  });
+
+  form.querySelectorAll('input[name="speed-direction"]').forEach((radio) => {
+    radio.addEventListener("change", () => {
+      if (valueInput.value !== "") {
+        convert();
+      }
+    });
+  });
+})();

--- a/public/js/time-zone-converter.js
+++ b/public/js/time-zone-converter.js
@@ -1,0 +1,295 @@
+(function () {
+  const form = document.getElementById("time-form");
+  const dateInput = document.getElementById("tz-datetime");
+  const fromSelect = document.getElementById("tz-from");
+  const targetsContainer = document.getElementById("tz-targets");
+  const resultEl = document.getElementById("time-result");
+
+  if (!form || !dateInput || !fromSelect || !targetsContainer || !resultEl) {
+    return;
+  }
+
+  const timeZones = [
+    { id: "new_york", label: "New York, USA", timeZone: "America/New_York" },
+    {
+      id: "los_angeles",
+      label: "Los Angeles, USA",
+      timeZone: "America/Los_Angeles",
+    },
+    { id: "chicago", label: "Chicago, USA", timeZone: "America/Chicago" },
+    {
+      id: "mexico_city",
+      label: "Mexico City, Mexico",
+      timeZone: "America/Mexico_City",
+    },
+    {
+      id: "sao_paulo",
+      label: "São Paulo, Brazil",
+      timeZone: "America/Sao_Paulo",
+    },
+    { id: "london", label: "London, UK", timeZone: "Europe/London" },
+    { id: "paris", label: "Paris, France", timeZone: "Europe/Paris" },
+    { id: "berlin", label: "Berlin, Germany", timeZone: "Europe/Berlin" },
+    {
+      id: "johannesburg",
+      label: "Johannesburg, South Africa",
+      timeZone: "Africa/Johannesburg",
+    },
+    { id: "dubai", label: "Dubai, UAE", timeZone: "Asia/Dubai" },
+    { id: "mumbai", label: "Mumbai, India", timeZone: "Asia/Kolkata" },
+    { id: "singapore", label: "Singapore", timeZone: "Asia/Singapore" },
+    { id: "tokyo", label: "Tokyo, Japan", timeZone: "Asia/Tokyo" },
+    { id: "sydney", label: "Sydney, Australia", timeZone: "Australia/Sydney" },
+    {
+      id: "auckland",
+      label: "Auckland, New Zealand",
+      timeZone: "Pacific/Auckland",
+    },
+  ];
+
+  const defaultComparisons = new Set([
+    "london",
+    "los_angeles",
+    "tokyo",
+    "sydney",
+  ]);
+
+  function setDefaultDateTime() {
+    const now = new Date();
+    now.setSeconds(0);
+    now.setMilliseconds(0);
+
+    const pad = (value) => String(value).padStart(2, "0");
+    const formatted = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(
+      now.getMinutes(),
+    )}`;
+
+    dateInput.value = formatted;
+    dateInput.defaultValue = formatted;
+  }
+
+  function getZoneById(id) {
+    return timeZones.find((zone) => zone.id === id);
+  }
+
+  function createOption(zone) {
+    const option = document.createElement("option");
+    option.value = zone.id;
+    option.textContent = zone.label;
+    if (zone.id === "new_york") {
+      option.selected = true;
+      option.defaultSelected = true;
+    }
+    return option;
+  }
+
+  function createCheckbox(zone) {
+    const label = document.createElement("label");
+    label.style.display = "flex";
+    label.style.alignItems = "center";
+    label.style.gap = "8px";
+    label.style.padding = "6px 8px";
+    label.style.borderRadius = "10px";
+    label.style.background = "rgba(78, 140, 255, 0.08)";
+
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.value = zone.id;
+    checkbox.checked = defaultComparisons.has(zone.id);
+    checkbox.defaultChecked = checkbox.checked;
+
+    const span = document.createElement("span");
+    span.textContent = zone.label;
+
+    label.appendChild(checkbox);
+    label.appendChild(span);
+
+    return label;
+  }
+
+  function parseDateTime(value) {
+    if (!value || typeof value !== "string") {
+      return null;
+    }
+
+    const [datePart, timePart] = value.split("T");
+    if (!datePart || !timePart) {
+      return null;
+    }
+
+    const [year, month, day] = datePart
+      .split("-")
+      .map((part) => Number.parseInt(part, 10));
+    const [hour, minute] = timePart
+      .split(":")
+      .map((part) => Number.parseInt(part, 10));
+
+    if ([year, month, day, hour, minute].some((part) => Number.isNaN(part))) {
+      return null;
+    }
+
+    return { year, month, day, hour, minute };
+  }
+
+  function getTimeZoneData(timeZone, date) {
+    const formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hourCycle: "h23",
+    });
+
+    const parts = formatter.formatToParts(date);
+    const data = {};
+    for (const part of parts) {
+      if (part.type !== "literal") {
+        data[part.type] = part.value;
+      }
+    }
+
+    const asUtc = Date.UTC(
+      Number.parseInt(data.year, 10),
+      Number.parseInt(data.month, 10) - 1,
+      Number.parseInt(data.day, 10),
+      Number.parseInt(data.hour, 10),
+      Number.parseInt(data.minute, 10),
+      Number.parseInt(data.second, 10),
+    );
+
+    return {
+      parts: data,
+      offset: asUtc - date.getTime(),
+    };
+  }
+
+  function formatDifference(diffHours) {
+    if (!Number.isFinite(diffHours) || Math.abs(diffHours) < 1e-9) {
+      return "Same time";
+    }
+
+    const rounded = Math.round(Math.abs(diffHours) * 10) / 10;
+    const display = Number.isInteger(rounded)
+      ? rounded.toString()
+      : rounded.toFixed(1);
+    const unit = rounded === 1 ? "hour" : "hours";
+
+    return diffHours > 0
+      ? `Ahead by ${display} ${unit}`
+      : `Behind by ${display} ${unit}`;
+  }
+
+  function render() {
+    const parsed = parseDateTime(dateInput.value);
+    const fromZone = getZoneById(fromSelect.value) ?? timeZones[0];
+
+    if (!parsed || !fromZone) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a valid date and time.</p></section>`;
+      return;
+    }
+
+    const candidateUtc = Date.UTC(
+      parsed.year,
+      parsed.month - 1,
+      parsed.day,
+      parsed.hour,
+      parsed.minute,
+    );
+    const candidateDate = new Date(candidateUtc);
+
+    const fromCandidate = getTimeZoneData(fromZone.timeZone, candidateDate);
+    const utcDate = new Date(candidateDate.getTime() - fromCandidate.offset);
+
+    const fromActual = getTimeZoneData(fromZone.timeZone, utcDate);
+
+    const matchesInput =
+      Number.parseInt(fromActual.parts.year, 10) === parsed.year &&
+      Number.parseInt(fromActual.parts.month, 10) === parsed.month &&
+      Number.parseInt(fromActual.parts.day, 10) === parsed.day &&
+      Number.parseInt(fromActual.parts.hour, 10) === parsed.hour &&
+      Number.parseInt(fromActual.parts.minute, 10) === parsed.minute;
+
+    if (!matchesInput) {
+      resultEl.innerHTML = `<section class="card"><p>The selected time does not exist in ${fromZone.label}—likely due to a daylight saving shift. Try a different time.</p></section>`;
+      return;
+    }
+
+    const checkboxes = Array.from(
+      targetsContainer.querySelectorAll('input[type="checkbox"]'),
+    );
+    const selectedZones = checkboxes
+      .filter((input) => input.checked)
+      .map((input) => getZoneById(input.value))
+      .filter(Boolean);
+
+    if (selectedZones.length === 0) {
+      resultEl.innerHTML = `<section class="card"><p>Select at least one destination city to compare.</p></section>`;
+      return;
+    }
+
+    const fromFormatter = new Intl.DateTimeFormat(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+      timeZone: fromZone.timeZone,
+    });
+
+    const rows = selectedZones
+      .map((zone) => {
+        const formatter = new Intl.DateTimeFormat(undefined, {
+          dateStyle: "medium",
+          timeStyle: "short",
+          timeZone: zone.timeZone,
+        });
+        const zoneData = getTimeZoneData(zone.timeZone, utcDate);
+        const diffHours =
+          (zoneData.offset - fromActual.offset) / (1000 * 60 * 60);
+        return `<tr><th scope="row">${zone.label}</th><td>${formatter.format(utcDate)}</td><td>${formatDifference(diffHours)}</td></tr>`;
+      })
+      .join("");
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">${fromFormatter.format(utcDate)} in ${fromZone.label}</h2>
+        <div class="table-wrap" style="margin-top:12px;">
+          <table>
+            <thead>
+              <tr><th scope="col">City</th><th scope="col">Local time</th><th scope="col">Offset vs. ${fromZone.label}</th></tr>
+            </thead>
+            <tbody>${rows}</tbody>
+          </table>
+        </div>
+        <p class="helper" style="margin-top:12px;">All offsets account for daylight saving time when applicable.</p>
+      </section>
+    `;
+  }
+
+  timeZones.forEach((zone) => {
+    fromSelect.appendChild(createOption(zone));
+    targetsContainer.appendChild(createCheckbox(zone));
+  });
+
+  setDefaultDateTime();
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    render();
+  });
+
+  form.addEventListener("reset", () => {
+    window.setTimeout(() => {
+      fromSelect.value = "new_york";
+      setDefaultDateTime();
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+
+  fromSelect.addEventListener("change", render);
+  dateInput.addEventListener("change", render);
+  dateInput.addEventListener("input", render);
+  targetsContainer.addEventListener("change", render);
+
+  render();
+})();

--- a/public/js/unit-converter.js
+++ b/public/js/unit-converter.js
@@ -1,0 +1,237 @@
+(function () {
+  const form = document.getElementById("unit-form");
+  const categorySelect = document.getElementById("unit-category");
+  const fromSelect = document.getElementById("unit-from");
+  const toSelect = document.getElementById("unit-to");
+  const amountInput = document.getElementById("unit-amount");
+  const resultEl = document.getElementById("unit-result");
+
+  if (
+    !form ||
+    !categorySelect ||
+    !fromSelect ||
+    !toSelect ||
+    !amountInput ||
+    !resultEl
+  ) {
+    return;
+  }
+
+  const linearUnit = (label, factor) => ({
+    label,
+    toBase: (value) => value * factor,
+    fromBase: (value) => value / factor,
+  });
+
+  const unitGroups = {
+    length: {
+      label: "Length",
+      units: {
+        meter: linearUnit("Meters (m)", 1),
+        kilometer: linearUnit("Kilometers (km)", 1000),
+        centimeter: linearUnit("Centimeters (cm)", 0.01),
+        millimeter: linearUnit("Millimeters (mm)", 0.001),
+        micrometer: linearUnit("Micrometers (µm)", 0.000001),
+        mile: linearUnit("Miles (mi)", 1609.344),
+        yard: linearUnit("Yards (yd)", 0.9144),
+        foot: linearUnit("Feet (ft)", 0.3048),
+        inch: linearUnit("Inches (in)", 0.0254),
+        nauticalMile: linearUnit("Nautical miles (NM)", 1852),
+      },
+    },
+    weight: {
+      label: "Weight",
+      units: {
+        gram: linearUnit("Grams (g)", 1),
+        kilogram: linearUnit("Kilograms (kg)", 1000),
+        milligram: linearUnit("Milligrams (mg)", 0.001),
+        metricTon: linearUnit("Metric tons (t)", 1_000_000),
+        ounce: linearUnit("Ounces (oz)", 28.349523125),
+        pound: linearUnit("Pounds (lb)", 453.59237),
+        stone: linearUnit("Stones (st)", 6350.29318),
+      },
+    },
+    temperature: {
+      label: "Temperature",
+      units: {
+        celsius: {
+          label: "Celsius (°C)",
+          toBase: (value) => value,
+          fromBase: (value) => value,
+        },
+        fahrenheit: {
+          label: "Fahrenheit (°F)",
+          toBase: (value) => ((value - 32) * 5) / 9,
+          fromBase: (value) => (value * 9) / 5 + 32,
+        },
+        kelvin: {
+          label: "Kelvin (K)",
+          toBase: (value) => value - 273.15,
+          fromBase: (value) => value + 273.15,
+        },
+        rankine: {
+          label: "Rankine (°R)",
+          toBase: (value) => ((value - 491.67) * 5) / 9,
+          fromBase: (value) => (value * 9) / 5 + 491.67,
+        },
+      },
+    },
+    volume: {
+      label: "Volume",
+      units: {
+        milliliter: linearUnit("Milliliters (mL)", 1),
+        liter: linearUnit("Liters (L)", 1000),
+        teaspoon: linearUnit("Teaspoons (tsp)", 4.92892159375),
+        tablespoon: linearUnit("Tablespoons (Tbsp)", 14.78676478125),
+        fluidOunce: linearUnit("Fluid ounces (fl oz)", 29.5735295625),
+        cup: linearUnit("Cups (US)", 236.5882365),
+        pint: linearUnit("Pints (US)", 473.176473),
+        quart: linearUnit("Quarts (US)", 946.352946),
+        gallon: linearUnit("Gallons (US)", 3785.411784),
+        cubicMeter: linearUnit("Cubic meters (m³)", 1_000_000),
+      },
+    },
+  };
+
+  function populateUnits(categoryId) {
+    const category = unitGroups[categoryId];
+    if (!category) {
+      return;
+    }
+
+    const previousFrom = fromSelect.value;
+    const previousTo = toSelect.value;
+
+    fromSelect.innerHTML = "";
+    toSelect.innerHTML = "";
+
+    Object.entries(category.units).forEach(([id, unit]) => {
+      const fromOption = document.createElement("option");
+      fromOption.value = id;
+      fromOption.textContent = unit.label;
+      fromSelect.appendChild(fromOption);
+
+      const toOption = document.createElement("option");
+      toOption.value = id;
+      toOption.textContent = unit.label;
+      toSelect.appendChild(toOption);
+    });
+
+    if (category.units[previousFrom]) {
+      fromSelect.value = previousFrom;
+    } else {
+      fromSelect.selectedIndex = 0;
+    }
+
+    if (category.units[previousTo]) {
+      toSelect.value = previousTo;
+    } else {
+      toSelect.selectedIndex = Math.min(1, toSelect.options.length - 1);
+    }
+
+    if (fromSelect.value === toSelect.value && toSelect.options.length > 1) {
+      const nextIndex =
+        (fromSelect.selectedIndex + 1) % toSelect.options.length;
+      toSelect.selectedIndex = nextIndex;
+    }
+  }
+
+  function formatValue(value, categoryId) {
+    if (!Number.isFinite(value)) {
+      return "-";
+    }
+
+    const abs = Math.abs(value);
+    let maximumFractionDigits = 4;
+
+    if (categoryId === "temperature") {
+      maximumFractionDigits = abs < 1 ? 3 : 2;
+    } else if (abs >= 10000) {
+      maximumFractionDigits = 2;
+    } else if (abs < 1) {
+      maximumFractionDigits = 6;
+    }
+
+    return value.toLocaleString(undefined, {
+      maximumFractionDigits,
+      minimumFractionDigits: 0,
+    });
+  }
+
+  function convert() {
+    const categoryId = categorySelect.value;
+    const category = unitGroups[categoryId];
+    if (!category) {
+      resultEl.innerHTML = "";
+      return;
+    }
+
+    const fromUnit = category.units[fromSelect.value];
+    const toUnit = category.units[toSelect.value];
+
+    const amount = Number.parseFloat(amountInput.value);
+    if (!Number.isFinite(amount)) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a valid number to convert.</p></section>`;
+      return;
+    }
+
+    if (!fromUnit || !toUnit) {
+      resultEl.innerHTML = `<section class="card"><p>Select units to convert between.</p></section>`;
+      return;
+    }
+
+    const baseValue = fromUnit.toBase(amount);
+    const converted = toUnit.fromBase(baseValue);
+
+    const rows = Object.entries(category.units)
+      .map(([id, unit]) => {
+        const value = unit.fromBase(baseValue);
+        return `<tr><th scope="row">${unit.label}</th><td>${formatValue(value, categoryId)}</td></tr>`;
+      })
+      .join("");
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">${formatValue(amount, categoryId)} ${category.units[fromSelect.value].label} = ${formatValue(
+          converted,
+          categoryId,
+        )} ${category.units[toSelect.value].label}</h2>
+        <div class="table-wrap" style="margin-top:12px;">
+          <table>
+            <thead>
+              <tr><th scope="col">Unit</th><th scope="col">Value</th></tr>
+            </thead>
+            <tbody>${rows}</tbody>
+          </table>
+        </div>
+        <p class="helper" style="margin-top:12px;">Values are rounded for readability but calculated using precise conversion factors.</p>
+      </section>
+    `;
+  }
+
+  categorySelect.addEventListener("change", () => {
+    populateUnits(categorySelect.value);
+    convert();
+  });
+
+  fromSelect.addEventListener("change", convert);
+  toSelect.addEventListener("change", convert);
+  amountInput.addEventListener("input", convert);
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    convert();
+  });
+
+  form.addEventListener("reset", () => {
+    window.setTimeout(() => {
+      categorySelect.value = "length";
+      populateUnits(categorySelect.value);
+      amountInput.value = "1";
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+
+  populateUnits(categorySelect.value || "length");
+  convert();
+})();

--- a/src/lib/calculatorData.ts
+++ b/src/lib/calculatorData.ts
@@ -20,13 +20,15 @@ export const calculatorCategories: CalculatorCategory[] = [
         href: "/calculators/days-from-date",
         name: "Days From (or Until) a Date",
         navLabel: "Days From Date",
-        description: "Find how many days are between any two dates—or from today.",
+        description:
+          "Find how many days are between any two dates—or from today.",
       },
       {
         href: "/calculators/age-calculator",
         name: "Age Calculator",
         navLabel: "Age",
-        description: "Enter a birthdate to see your age in years, months, and days.",
+        description:
+          "Enter a birthdate to see your age in years, months, and days.",
       },
       {
         href: "/calculators/days-until-birthday",
@@ -38,7 +40,8 @@ export const calculatorCategories: CalculatorCategory[] = [
         href: "/calculators/anniversary-countdown",
         name: "Anniversary Countdown",
         navLabel: "Anniversary",
-        description: "Preview the next few anniversaries for any meaningful date.",
+        description:
+          "Preview the next few anniversaries for any meaningful date.",
       },
       {
         href: "/calculators/holiday-countdown",
@@ -56,49 +59,112 @@ export const calculatorCategories: CalculatorCategory[] = [
         href: "/calculators/loan-calculator",
         name: "Loan Calculator",
         navLabel: "Loan",
-        description: "Estimate payments and see principal versus interest by year.",
+        description:
+          "Estimate payments and see principal versus interest by year.",
       },
       {
         href: "/calculators/mortgage-calculator",
         name: "Mortgage Planner",
         navLabel: "Mortgage",
-        description: "Check affordability, monthly costs, and an amortization schedule.",
+        description:
+          "Check affordability, monthly costs, and an amortization schedule.",
       },
       {
         href: "/calculators/compound-interest-calculator",
         name: "Compound Interest",
         navLabel: "Invest",
-        description: "Model investment growth with recurring deposits and raises.",
+        description:
+          "Model investment growth with recurring deposits and raises.",
       },
       {
         href: "/calculators/currency-converter",
         name: "Currency Converter",
         navLabel: "Currency",
-        description: "Convert between 30+ currencies with live-rate fallback support.",
+        description:
+          "Convert between 30+ currencies with live-rate fallback support.",
       },
       {
         href: "/calculators/inflation-calculator",
         name: "Inflation Adjuster",
         navLabel: "Inflation",
-        description: "Compare the buying power of money across different years.",
+        description:
+          "Compare the buying power of money across different years.",
       },
       {
         href: "/calculators/salary-to-hourly",
         name: "Salary ↔ Hourly",
         navLabel: "Salary",
-        description: "Convert yearly pay to hourly wages (and vice versa) with your schedule.",
+        description:
+          "Convert yearly pay to hourly wages (and vice versa) with your schedule.",
       },
       {
         href: "/calculators/tip-calculator",
         name: "Tip Splitter",
         navLabel: "Tip",
-        description: "Quickly find tip amounts and per-person totals for the table.",
+        description:
+          "Quickly find tip amounts and per-person totals for the table.",
       },
       {
         href: "/calculators/savings-goal-calculator",
         name: "Savings Goal",
         navLabel: "Savings",
-        description: "See the monthly deposit needed to reach a target with growth.",
+        description:
+          "See the monthly deposit needed to reach a target with growth.",
+      },
+    ],
+  },
+  {
+    id: "conversions",
+    label: "Converters & Units",
+    calculators: [
+      {
+        href: "/calculators/unit-converter",
+        name: "Unit Converter",
+        navLabel: "Units",
+        description:
+          "Switch between length, weight, temperature, and volume measurements with precise factors.",
+      },
+      {
+        href: "/calculators/time-zone-converter",
+        name: "Time Zone Converter",
+        navLabel: "Time Zones",
+        description:
+          "Enter a city and instantly compare the time across world capitals—DST aware.",
+      },
+      {
+        href: "/calculators/cooking-measurement-converter",
+        name: "Cooking Measurement Converter",
+        navLabel: "Cooking",
+        description:
+          "Translate cups, grams, ounces, and spoons with a water-based kitchen reference.",
+      },
+      {
+        href: "/calculators/fuel-economy-converter",
+        name: "Fuel Economy Converter",
+        navLabel: "Fuel",
+        description:
+          "Swap between MPG and liters per 100 km when comparing vehicle efficiency.",
+      },
+      {
+        href: "/calculators/speed-converter",
+        name: "Speed Converter",
+        navLabel: "Speed",
+        description:
+          "Convert driving speeds between miles per hour and kilometers per hour.",
+      },
+      {
+        href: "/calculators/shoe-size-converter",
+        name: "Shoe Size Converter",
+        navLabel: "Shoes",
+        description:
+          "Match US, UK, and EU shoe sizes for men's and women's charts side by side.",
+      },
+      {
+        href: "/calculators/clothing-size-converter",
+        name: "Clothing Size Converter",
+        navLabel: "Clothing",
+        description:
+          "Find approximate international equivalents for common men's and women's apparel sizes.",
       },
     ],
   },

--- a/src/pages/calculators/clothing-size-converter.astro
+++ b/src/pages/calculators/clothing-size-converter.astro
@@ -1,0 +1,58 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Clothing Size Converter";
+const description = "Find approximate international equivalents for men's and women's clothing sizes.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/clothing-size-converter">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Choose a gendered chart, select the sizing system you know, and we will display the closest matches for the other
+      regions. Use this as a starting point when shopping abroad.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="clothing-form">
+      <div class="form-grid columns-3">
+        <div>
+          <label for="clothing-profile">Sizing chart</label>
+          <select id="clothing-profile" name="profile">
+            <option value="women">Women's tops &amp; dresses</option>
+            <option value="men">Men's jackets &amp; shirts</option>
+          </select>
+        </div>
+        <div>
+          <label for="clothing-source">I know my size in</label>
+          <select id="clothing-source" name="source">
+            <option value="intl">International (XS-XXL)</option>
+            <option value="us">US</option>
+            <option value="uk">UK</option>
+            <option value="eu">EU</option>
+          </select>
+        </div>
+        <div>
+          <label for="clothing-size">Size</label>
+          <select id="clothing-size" name="size"></select>
+        </div>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Convert</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">
+        Apparel sizing is notoriously inconsistent. Treat these conversions as approximations and check each retailer's
+        guide when possible.
+      </p>
+    </form>
+  </section>
+
+  <section id="clothing-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="clothing-inline-1" />
+  <script defer src="/js/clothing-size-converter.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/cooking-measurement-converter.astro
+++ b/src/pages/calculators/cooking-measurement-converter.astro
@@ -1,0 +1,58 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Cooking Measurement Converter";
+const description = "Swap between cups, grams, ounces, tablespoons, and more with a kitchen-friendly reference.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/cooking-measurement-converter">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Convert between common baking and cooking measures. We assume water density (1 milliliter ≈ 1 gram) for quick
+      kitchen math.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="cooking-form">
+      <div class="form-grid columns-3">
+        <div>
+          <label for="cooking-amount">Amount</label>
+          <input
+            id="cooking-amount"
+            name="amount"
+            type="number"
+            step="any"
+            inputmode="decimal"
+            placeholder="2"
+            value="1"
+            required
+          />
+        </div>
+        <div>
+          <label for="cooking-from">From</label>
+          <select id="cooking-from" name="from"></select>
+        </div>
+        <div>
+          <label for="cooking-to">To</label>
+          <select id="cooking-to" name="to"></select>
+        </div>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Convert</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">
+        Need a quick kitchen math table? Scroll down after converting to see the amount expressed in every supported unit.
+      </p>
+    </form>
+  </section>
+
+  <section id="cooking-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="cooking-inline-1" />
+  <script defer src="/js/cooking-converter.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/fuel-economy-converter.astro
+++ b/src/pages/calculators/fuel-economy-converter.astro
@@ -1,0 +1,63 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Fuel Economy Converter";
+const description = "Translate MPG to liters per 100 km (and back) for easy vehicle comparisons.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/fuel-economy-converter">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Automakers quote efficiency in different systems. Enter the rating you know and we will convert it using the standard
+      235.21458 factor.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="fuel-form">
+      <div class="form-grid columns-3">
+        <div>
+          <label>Conversion direction</label>
+          <div style="display:flex; flex-direction:column; gap:6px;">
+            <label style="display:flex; align-items:center; gap:8px;">
+              <input type="radio" name="fuel-direction" value="mpg-to-l" checked />
+              <span>MPG → L/100 km</span>
+            </label>
+            <label style="display:flex; align-items:center; gap:8px;">
+              <input type="radio" name="fuel-direction" value="l-to-mpg" />
+              <span>L/100 km → MPG</span>
+            </label>
+          </div>
+        </div>
+        <div>
+          <label for="fuel-value">Value</label>
+          <input
+            id="fuel-value"
+            name="value"
+            type="number"
+            min="0"
+            step="any"
+            inputmode="decimal"
+            placeholder="30"
+            required
+          />
+        </div>
+        <div>
+          <label class="helper" style="margin-top:36px;">Zero or negative inputs are not allowed.</label>
+        </div>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Convert</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+    </form>
+  </section>
+
+  <section id="fuel-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="fuel-inline-1" />
+  <script defer src="/js/fuel-economy.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/shoe-size-converter.astro
+++ b/src/pages/calculators/shoe-size-converter.astro
@@ -1,0 +1,56 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Shoe Size Converter";
+const description = "Match men's and women's shoe sizes across US, UK, and EU charts.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/shoe-size-converter">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Choose men's or women's sizing, pick the system you know, and we'll show the equivalent sizes across the other
+      regions.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="shoe-form">
+      <div class="form-grid columns-3">
+        <div>
+          <label for="shoe-profile">Sizing chart</label>
+          <select id="shoe-profile" name="profile">
+            <option value="women">Women's</option>
+            <option value="men">Men's</option>
+          </select>
+        </div>
+        <div>
+          <label for="shoe-source">I know my size in</label>
+          <select id="shoe-source" name="source">
+            <option value="us">US</option>
+            <option value="uk">UK</option>
+            <option value="eu">EU</option>
+          </select>
+        </div>
+        <div>
+          <label for="shoe-size">Size</label>
+          <select id="shoe-size" name="size"></select>
+        </div>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Convert</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">
+        Charts vary slightly between brands. These numbers follow the most common conversion tables for street shoes.
+      </p>
+    </form>
+  </section>
+
+  <section id="shoe-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="shoe-inline-1" />
+  <script defer src="/js/shoe-size-converter.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/speed-converter.astro
+++ b/src/pages/calculators/speed-converter.astro
@@ -1,0 +1,62 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Speed Converter";
+const description = "Quickly swap between miles per hour and kilometers per hour.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/speed-converter">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Road trip abroad? Convert mph and km/h instantly using the exact 1 mile = 1.609344 kilometers conversion factor.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="speed-form">
+      <div class="form-grid columns-3">
+        <div>
+          <label>Conversion direction</label>
+          <div style="display:flex; flex-direction:column; gap:6px;">
+            <label style="display:flex; align-items:center; gap:8px;">
+              <input type="radio" name="speed-direction" value="mph-to-kmh" checked />
+              <span>mph → km/h</span>
+            </label>
+            <label style="display:flex; align-items:center; gap:8px;">
+              <input type="radio" name="speed-direction" value="kmh-to-mph" />
+              <span>km/h → mph</span>
+            </label>
+          </div>
+        </div>
+        <div>
+          <label for="speed-value">Value</label>
+          <input
+            id="speed-value"
+            name="value"
+            type="number"
+            min="0"
+            step="any"
+            inputmode="decimal"
+            placeholder="65"
+            required
+          />
+        </div>
+        <div>
+          <label class="helper" style="margin-top:36px;">Use decimals for cruise control precision.</label>
+        </div>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Convert</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+    </form>
+  </section>
+
+  <section id="speed-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="speed-inline-1" />
+  <script defer src="/js/speed-converter.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/time-zone-converter.astro
+++ b/src/pages/calculators/time-zone-converter.astro
@@ -1,0 +1,59 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Time Zone Converter";
+const description = "Compare the same moment across world cities with automatic daylight-saving handling.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/time-zone-converter">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Pick an origin city and date/time, then choose the destinations you care about. We'll show the matching local time in
+      each city and how far ahead or behind it is.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="time-form">
+      <div class="form-grid columns-3">
+        <div>
+          <label for="tz-datetime">Date &amp; time</label>
+          <input id="tz-datetime" name="datetime" type="datetime-local" required />
+          <p class="helper" style="margin-top:6px;">Enter the time in the origin city below.</p>
+        </div>
+        <div>
+          <label for="tz-from">Origin city</label>
+          <select id="tz-from" name="from"></select>
+        </div>
+        <div>
+          <label>Select cities to compare</label>
+          <div
+            id="tz-targets"
+            style="
+              display: grid;
+              gap: 6px;
+              grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+              padding: 8px;
+              border: 1px solid var(--border);
+              border-radius: 12px;
+              background: var(--panel-2);
+            "
+          ></div>
+          <p class="helper" style="margin-top:6px;">Choose as many cities as you like—we'll update instantly.</p>
+        </div>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Compare times</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+    </form>
+  </section>
+
+  <section id="time-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="time-inline-1" />
+  <script defer src="/js/time-zone-converter.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/unit-converter.astro
+++ b/src/pages/calculators/unit-converter.astro
@@ -1,0 +1,67 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Unit Converter";
+const description = "Convert between length, weight, temperature, and volume units with precise rounding.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/unit-converter">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Pick a measurement type, choose units, and enter an amount. We handle length, weight, temperature, and volume using
+      exact conversion factors.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="unit-form">
+      <label for="unit-category">Measurement type</label>
+      <select id="unit-category" name="category">
+        <option value="length">Length</option>
+        <option value="weight">Weight</option>
+        <option value="temperature">Temperature</option>
+        <option value="volume">Volume</option>
+      </select>
+
+      <div class="form-grid columns-3" style="margin-top:12px;">
+        <div>
+          <label for="unit-amount">Amount</label>
+          <input
+            id="unit-amount"
+            name="amount"
+            type="number"
+            inputmode="decimal"
+            step="any"
+            placeholder="10"
+            value="1"
+            required
+          />
+        </div>
+        <div>
+          <label for="unit-from">From unit</label>
+          <select id="unit-from" name="from"></select>
+        </div>
+        <div>
+          <label for="unit-to">To unit</label>
+          <select id="unit-to" name="to"></select>
+        </div>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Convert</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">
+        Results refresh automatically as you edit the amount or units. Temperature conversions use precise formulas rather
+        than rounding shortcuts.
+      </p>
+    </form>
+  </section>
+
+  <section id="unit-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="unit-inline-1" />
+  <script defer src="/js/unit-converter.js"></script>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- add a Converters & Units navigation category with unit, time zone, cooking, fuel, speed, shoe, and clothing tools
- create Astro pages for each converter with forms, helper text, and result containers
- implement front-end scripts to perform the conversions, handle DST-aware time comparisons, and map sizing datasets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8cac133b88323b65f9ed4b938e04b