### PR TITLE
Add health and fitness calculators

### DIFF
--- a/public/js/bmi-calculator.js
+++ b/public/js/bmi-calculator.js
@@ -1,0 +1,132 @@
+(function () {
+  const form = document.getElementById("bmi-form");
+  const resultEl = document.getElementById("bmi-result");
+  const unitSelect = document.getElementById("bmi-units");
+  const heightUnitEl = document.getElementById("bmi-height-unit");
+  const weightUnitEl = document.getElementById("bmi-weight-unit");
+  const heightInput = document.getElementById("bmi-height");
+  const weightInput = document.getElementById("bmi-weight");
+
+  if (!form || !resultEl || !unitSelect || !heightUnitEl || !weightUnitEl || !heightInput || !weightInput) {
+    return;
+  }
+
+  const PLACEHOLDERS = {
+    metric: { height: "170", weight: "70" },
+    imperial: { height: "67", weight: "154" },
+  };
+
+  function updateUnits() {
+    const unit = unitSelect.value === "imperial" ? "imperial" : "metric";
+    if (unit === "imperial") {
+      heightUnitEl.textContent = "(in)";
+      weightUnitEl.textContent = "(lb)";
+    } else {
+      heightUnitEl.textContent = "(cm)";
+      weightUnitEl.textContent = "(kg)";
+    }
+    heightInput.placeholder = PLACEHOLDERS[unit].height;
+    weightInput.placeholder = PLACEHOLDERS[unit].weight;
+  }
+
+  function classifyBmi(bmi) {
+    if (bmi < 18.5) return "Underweight";
+    if (bmi < 25) return "Healthy weight";
+    if (bmi < 30) return "Overweight";
+    if (bmi < 35) return "Obesity class I";
+    if (bmi < 40) return "Obesity class II";
+    return "Obesity class III";
+  }
+
+  function formatWeight(kg, units) {
+    if (units === "imperial") {
+      return `${(kg * 2.2046226218).toFixed(1)} lb`;
+    }
+    return `${kg.toFixed(1)} kg`;
+  }
+
+  function renderResult({ bmi, units, heightCm, weightKg }) {
+    const bmiRounded = bmi.toFixed(1);
+    const category = classifyBmi(bmi);
+    const heightDisplay =
+      units === "imperial" ? `${(heightCm / 2.54).toFixed(1)} in` : `${heightCm.toFixed(1)} cm`;
+
+    const healthyMinKg = 18.5 * Math.pow(heightCm / 100, 2);
+    const healthyMaxKg = 24.9 * Math.pow(heightCm / 100, 2);
+
+    const rangePrimary =
+      units === "imperial"
+        ? `${(healthyMinKg * 2.2046226218).toFixed(1)} – ${(healthyMaxKg * 2.2046226218).toFixed(1)} lb`
+        : `${healthyMinKg.toFixed(1)} – ${healthyMaxKg.toFixed(1)} kg`;
+    const rangeSecondary =
+      units === "imperial"
+        ? `${healthyMinKg.toFixed(1)} – ${healthyMaxKg.toFixed(1)} kg`
+        : `${(healthyMinKg * 2.2046226218).toFixed(1)} – ${(healthyMaxKg * 2.2046226218).toFixed(1)} lb`;
+
+    let changeMessage = "Already in the healthy BMI range";
+    if (bmi < 18.5) {
+      const gainKg = Math.max(0, healthyMinKg - weightKg);
+      changeMessage = `Gain about ${formatWeight(gainKg, units)} to reach a BMI of 18.5.`;
+    } else if (bmi > 24.9) {
+      const loseKg = Math.max(0, weightKg - healthyMaxKg);
+      changeMessage = `Lose about ${formatWeight(loseKg, units)} to reach a BMI of 24.9.`;
+    }
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">BMI: ${bmiRounded}</h2>
+        <div class="stat-grid">
+          <div class="stat"><span class="label">Category</span><span class="value">${category}</span></div>
+          <div class="stat"><span class="label">Healthy weight range</span><span class="value">${rangePrimary}</span><span class="helper" style="margin-top:6px;">${rangeSecondary}</span></div>
+          <div class="stat"><span class="label">Entered height</span><span class="value">${heightDisplay}</span></div>
+          <div class="stat"><span class="label">Adjustment guide</span><span class="value">${changeMessage}</span></div>
+        </div>
+        <p class="helper" style="margin-top:12px;">BMI is a screening tool and can read high for athletes with more muscle mass. Check in with a clinician for a full assessment.</p>
+      </section>
+    `;
+  }
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const units = unitSelect.value === "imperial" ? "imperial" : "metric";
+    const heightInputValue = parseFloat(heightInput.value || "0");
+    const weightInputValue = parseFloat(weightInput.value || "0");
+
+    if (!Number.isFinite(heightInputValue) || heightInputValue <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a height greater than zero.</p></section>`;
+      return;
+    }
+
+    if (!Number.isFinite(weightInputValue) || weightInputValue <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a weight greater than zero.</p></section>`;
+      return;
+    }
+
+    const heightCm = units === "imperial" ? heightInputValue * 2.54 : heightInputValue;
+    const weightKg = units === "imperial" ? weightInputValue * 0.45359237 : weightInputValue;
+    const heightMeters = heightCm / 100;
+
+    if (heightMeters <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Height must be greater than zero.</p></section>`;
+      return;
+    }
+
+    const bmi = weightKg / Math.pow(heightMeters, 2);
+    if (!Number.isFinite(bmi) || bmi <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Unable to calculate BMI. Check your entries.</p></section>`;
+      return;
+    }
+
+    renderResult({ bmi, units, heightCm, weightKg });
+  });
+
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      updateUnits();
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+
+  unitSelect.addEventListener("change", updateUnits);
+  updateUnits();
+})();

--- a/public/js/bmr-calorie.js
+++ b/public/js/bmr-calorie.js
@@ -1,0 +1,122 @@
+(function () {
+  const form = document.getElementById("bmr-form");
+  const resultEl = document.getElementById("bmr-result");
+  const unitSelect = document.getElementById("bmr-units");
+  const heightUnitEl = document.getElementById("bmr-height-unit");
+  const weightUnitEl = document.getElementById("bmr-weight-unit");
+  const heightInput = document.getElementById("bmr-height");
+  const weightInput = document.getElementById("bmr-weight");
+  const activitySelect = document.getElementById("bmr-activity");
+
+  if (
+    !form ||
+    !resultEl ||
+    !unitSelect ||
+    !heightUnitEl ||
+    !weightUnitEl ||
+    !heightInput ||
+    !weightInput ||
+    !activitySelect
+  ) {
+    return;
+  }
+
+  const PLACEHOLDERS = {
+    metric: { height: "170", weight: "70" },
+    imperial: { height: "67", weight: "154" },
+  };
+
+  function updateUnits() {
+    const unit = unitSelect.value === "imperial" ? "imperial" : "metric";
+    if (unit === "imperial") {
+      heightUnitEl.textContent = "(in)";
+      weightUnitEl.textContent = "(lb)";
+    } else {
+      heightUnitEl.textContent = "(cm)";
+      weightUnitEl.textContent = "(kg)";
+    }
+    heightInput.placeholder = PLACEHOLDERS[unit].height;
+    weightInput.placeholder = PLACEHOLDERS[unit].weight;
+  }
+
+  function roundToTen(value) {
+    return Math.round(value / 10) * 10;
+  }
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+
+    const gender = form.gender?.value || "female";
+    const age = parseFloat(form.age?.value || "0");
+    const units = unitSelect.value === "imperial" ? "imperial" : "metric";
+    const heightVal = parseFloat(heightInput.value || "0");
+    const weightVal = parseFloat(weightInput.value || "0");
+    const activityFactor = parseFloat(activitySelect.value || "1");
+    const activityLabel = activitySelect.options[activitySelect.selectedIndex]?.textContent || "";
+
+    if (!Number.isFinite(age) || age <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter an age above zero.</p></section>`;
+      return;
+    }
+
+    if (!Number.isFinite(heightVal) || heightVal <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a height above zero.</p></section>`;
+      return;
+    }
+
+    if (!Number.isFinite(weightVal) || weightVal <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a weight above zero.</p></section>`;
+      return;
+    }
+
+    if (!Number.isFinite(activityFactor) || activityFactor <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Select an activity level.</p></section>`;
+      return;
+    }
+
+    const heightCm = units === "imperial" ? heightVal * 2.54 : heightVal;
+    const weightKg = units === "imperial" ? weightVal * 0.45359237 : weightVal;
+
+    const bmr =
+      10 * weightKg + 6.25 * heightCm - 5 * age + (gender === "male" ? 5 : -161);
+
+    const maintenance = bmr * activityFactor;
+    const mildDeficit = Math.max(maintenance - 250, bmr * 0.95);
+    const moderateDeficit = Math.max(maintenance - 500, bmr * 0.9);
+    const surplus = maintenance + 250;
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">Daily energy targets</h2>
+        <div class="stat-grid">
+          <div class="stat"><span class="label">Basal metabolic rate</span><span class="value">${roundToTen(
+            bmr
+          ).toLocaleString()} kcal</span></div>
+          <div class="stat"><span class="label">Maintenance calories</span><span class="value">${roundToTen(
+            maintenance
+          ).toLocaleString()} kcal</span><span class="helper" style="margin-top:6px;">${activityLabel}</span></div>
+          <div class="stat"><span class="label">Gentle deficit</span><span class="value">${roundToTen(
+            mildDeficit
+          ).toLocaleString()} kcal</span><span class="helper" style="margin-top:6px;">≈250 kcal below maintenance</span></div>
+          <div class="stat"><span class="label">Moderate deficit</span><span class="value">${roundToTen(
+            moderateDeficit
+          ).toLocaleString()} kcal</span><span class="helper" style="margin-top:6px;">≈500 kcal below maintenance</span></div>
+          <div class="stat"><span class="label">Lean bulk</span><span class="value">${roundToTen(
+            surplus
+          ).toLocaleString()} kcal</span><span class="helper" style="margin-top:6px;">≈250 kcal above maintenance</span></div>
+        </div>
+        <p class="helper" style="margin-top:12px;">Calorie ranges are estimates—monitor energy, recovery, and progress, and adjust weekly if needed.</p>
+      </section>
+    `;
+  });
+
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      updateUnits();
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+
+  unitSelect.addEventListener("change", updateUnits);
+  updateUnits();
+})();

--- a/public/js/body-fat-estimator.js
+++ b/public/js/body-fat-estimator.js
@@ -1,0 +1,195 @@
+(function () {
+  const form = document.getElementById("body-fat-form");
+  const resultEl = document.getElementById("body-fat-result");
+  const unitSelect = document.getElementById("body-fat-units");
+  const sexSelect = document.getElementById("body-fat-sex");
+  const hipGroup = document.getElementById("body-fat-hip-group");
+  const weightUnitEl = document.getElementById("body-fat-weight-unit");
+  const heightUnitEl = document.getElementById("body-fat-height-unit");
+  const neckUnitEl = document.getElementById("body-fat-neck-unit");
+  const waistUnitEl = document.getElementById("body-fat-waist-unit");
+  const hipUnitEl = document.getElementById("body-fat-hip-unit");
+  const weightInput = document.getElementById("body-fat-weight");
+  const heightInput = document.getElementById("body-fat-height");
+  const neckInput = document.getElementById("body-fat-neck");
+  const waistInput = document.getElementById("body-fat-waist");
+  const hipInput = document.getElementById("body-fat-hip");
+
+  if (
+    !form ||
+    !resultEl ||
+    !unitSelect ||
+    !sexSelect ||
+    !hipGroup ||
+    !weightUnitEl ||
+    !heightUnitEl ||
+    !neckUnitEl ||
+    !waistUnitEl ||
+    !hipUnitEl ||
+    !weightInput ||
+    !heightInput ||
+    !neckInput ||
+    !waistInput ||
+    !hipInput
+  ) {
+    return;
+  }
+
+  const PLACEHOLDERS = {
+    metric: { weight: "75", height: "175", neck: "38", waist: "85", hip: "95" },
+    imperial: { weight: "165", height: "69", neck: "15", waist: "34", hip: "37" },
+  };
+
+  function updateUnits() {
+    const unit = unitSelect.value === "imperial" ? "imperial" : "metric";
+    if (unit === "imperial") {
+      weightUnitEl.textContent = "(lb)";
+      heightUnitEl.textContent = "(in)";
+      neckUnitEl.textContent = "(in)";
+      waistUnitEl.textContent = "(in)";
+      hipUnitEl.textContent = "(in)";
+    } else {
+      weightUnitEl.textContent = "(kg)";
+      heightUnitEl.textContent = "(cm)";
+      neckUnitEl.textContent = "(cm)";
+      waistUnitEl.textContent = "(cm)";
+      hipUnitEl.textContent = "(cm)";
+    }
+    weightInput.placeholder = PLACEHOLDERS[unit].weight;
+    heightInput.placeholder = PLACEHOLDERS[unit].height;
+    neckInput.placeholder = PLACEHOLDERS[unit].neck;
+    waistInput.placeholder = PLACEHOLDERS[unit].waist;
+    hipInput.placeholder = PLACEHOLDERS[unit].hip;
+  }
+
+  function updateHipVisibility() {
+    const isFemale = sexSelect.value === "female";
+    hipGroup.style.display = isFemale ? "block" : "none";
+    if (!isFemale) {
+      hipInput.value = "";
+    }
+  }
+
+  function log10(value) {
+    return Math.log(value) / Math.log(10);
+  }
+
+  function categoryFor(sex, bodyFat) {
+    if (sex === "female") {
+      if (bodyFat < 14) return "Essential";
+      if (bodyFat < 21) return "Athlete";
+      if (bodyFat < 25) return "Fitness";
+      if (bodyFat < 32) return "Average";
+      return "Above average";
+    }
+    if (bodyFat < 6) return "Essential";
+    if (bodyFat < 14) return "Athlete";
+    if (bodyFat < 18) return "Fitness";
+    if (bodyFat < 25) return "Average";
+    return "Above average";
+  }
+
+  function formatMass(kg, units) {
+    const pounds = kg * 2.2046226218;
+    if (units === "imperial") {
+      return `${pounds.toFixed(1)} lb (${kg.toFixed(1)} kg)`;
+    }
+    return `${kg.toFixed(1)} kg (${pounds.toFixed(1)} lb)`;
+  }
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+
+    const sex = sexSelect.value === "female" ? "female" : "male";
+    const units = unitSelect.value === "imperial" ? "imperial" : "metric";
+
+    const weightVal = parseFloat(weightInput.value || "0");
+    const heightVal = parseFloat(heightInput.value || "0");
+    const neckVal = parseFloat(neckInput.value || "0");
+    const waistVal = parseFloat(waistInput.value || "0");
+    const hipVal = parseFloat(hipInput.value || "0");
+
+    if (!Number.isFinite(weightVal) || weightVal <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a body weight above zero.</p></section>`;
+      return;
+    }
+    if (!Number.isFinite(heightVal) || heightVal <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a height above zero.</p></section>`;
+      return;
+    }
+    if (!Number.isFinite(neckVal) || neckVal <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a neck measurement above zero.</p></section>`;
+      return;
+    }
+    if (!Number.isFinite(waistVal) || waistVal <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a waist measurement above zero.</p></section>`;
+      return;
+    }
+    if (sex === "female" && (!Number.isFinite(hipVal) || hipVal <= 0)) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a hip measurement above zero for the female formula.</p></section>`;
+      return;
+    }
+
+    const heightIn = units === "imperial" ? heightVal : heightVal / 2.54;
+    const neckIn = units === "imperial" ? neckVal : neckVal / 2.54;
+    const waistIn = units === "imperial" ? waistVal : waistVal / 2.54;
+    const hipIn = units === "imperial" ? hipVal : hipVal / 2.54;
+
+    if (sex === "male" && waistIn - neckIn <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Waist must be larger than neck for the male formula.</p></section>`;
+      return;
+    }
+    if (sex === "female" && waistIn + hipIn - neckIn <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Waist plus hip must be larger than neck for the female formula.</p></section>`;
+      return;
+    }
+
+    let bodyFat;
+    if (sex === "male") {
+      bodyFat = 495 / (1.0324 - 0.19077 * log10(waistIn - neckIn) + 0.15456 * log10(heightIn)) - 450;
+    } else {
+      bodyFat = 495 /
+        (1.29579 - 0.35004 * log10(waistIn + hipIn - neckIn) + 0.221 * log10(heightIn)) -
+        450;
+    }
+
+    if (!Number.isFinite(bodyFat) || bodyFat <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Unable to calculate body fat with these numbers. Double-check your measurements.</p></section>`;
+      return;
+    }
+
+    const weightKg = units === "imperial" ? weightVal * 0.45359237 : weightVal;
+    const fatMassKg = weightKg * (bodyFat / 100);
+    const leanMassKg = weightKg - fatMassKg;
+
+    const category = categoryFor(sex, bodyFat);
+    const leanDisplay = formatMass(leanMassKg, units);
+    const fatDisplay = formatMass(fatMassKg, units);
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">Estimated body fat: ${bodyFat.toFixed(1)}%</h2>
+        <div class="stat-grid">
+          <div class="stat"><span class="label">Category</span><span class="value">${category}</span></div>
+          <div class="stat"><span class="label">Lean body mass</span><span class="value">${leanDisplay}</span></div>
+          <div class="stat"><span class="label">Fat mass</span><span class="value">${fatDisplay}</span></div>
+          <div class="stat"><span class="label">Tape inputs</span><span class="value">${sex === "female" ? "Waist + hip − neck" : "Waist − neck"}</span></div>
+        </div>
+        <p class="helper" style="margin-top:12px;">This method provides an estimate. For a medical evaluation, use a DEXA scan or consult a qualified professional.</p>
+      </section>
+    `;
+  });
+
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      updateUnits();
+      updateHipVisibility();
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+
+  unitSelect.addEventListener("change", updateUnits);
+  sexSelect.addEventListener("change", updateHipVisibility);
+  updateUnits();
+  updateHipVisibility();
+})();

--- a/public/js/macros-calculator.js
+++ b/public/js/macros-calculator.js
@@ -1,0 +1,180 @@
+(function () {
+  const form = document.getElementById("macros-form");
+  const resultEl = document.getElementById("macros-result");
+  const unitSelect = document.getElementById("macros-units");
+  const weightUnitEl = document.getElementById("macros-weight-unit");
+  const weightInput = document.getElementById("macros-weight");
+  const caloriesInput = document.getElementById("macros-calories");
+  const goalSelect = document.getElementById("macro-goal");
+  const customFields = document.getElementById("custom-macro-fields");
+  const customProtein = document.getElementById("macro-protein");
+  const customCarbs = document.getElementById("macro-carbs");
+  const customFat = document.getElementById("macro-fat");
+
+  if (
+    !form ||
+    !resultEl ||
+    !unitSelect ||
+    !weightUnitEl ||
+    !weightInput ||
+    !caloriesInput ||
+    !goalSelect ||
+    !customFields ||
+    !customProtein ||
+    !customCarbs ||
+    !customFat
+  ) {
+    return;
+  }
+
+  const PLACEHOLDERS = { metric: "75", imperial: "165" };
+
+  function updateUnits() {
+    const unit = unitSelect.value === "imperial" ? "imperial" : "metric";
+    weightUnitEl.textContent = unit === "imperial" ? "(lb)" : "(kg)";
+    weightInput.placeholder = PLACEHOLDERS[unit];
+  }
+
+  function handleGoalChange() {
+    if (goalSelect.value === "custom") {
+      customFields.style.display = "block";
+    } else {
+      customFields.style.display = "none";
+      customProtein.value = "";
+      customCarbs.value = "";
+      customFat.value = "";
+    }
+  }
+
+  function formatMacro(grams, percent) {
+    return `${Math.round(grams)} g (${Math.round(percent * 100)}%)`;
+  }
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+
+    const units = unitSelect.value === "imperial" ? "imperial" : "metric";
+    const weightVal = parseFloat(weightInput.value || "0");
+    const caloriesVal = parseFloat(caloriesInput.value || "0");
+
+    if (!Number.isFinite(weightVal) || weightVal <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a body weight above zero.</p></section>`;
+      return;
+    }
+
+    if (!Number.isFinite(caloriesVal) || caloriesVal <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a calorie goal above zero.</p></section>`;
+      return;
+    }
+
+    let proteinPct;
+    let carbPct;
+    let fatPct;
+    const selectedOption = goalSelect.options[goalSelect.selectedIndex];
+    let splitLabel = selectedOption?.textContent || "";
+
+    if (goalSelect.value === "custom") {
+      const proteinPercent = parseFloat(customProtein.value || "0");
+      const carbPercent = parseFloat(customCarbs.value || "0");
+      const fatPercent = parseFloat(customFat.value || "0");
+      const total = proteinPercent + carbPercent + fatPercent;
+
+      if (
+        !Number.isFinite(proteinPercent) ||
+        !Number.isFinite(carbPercent) ||
+        !Number.isFinite(fatPercent)
+      ) {
+        resultEl.innerHTML = `<section class="card"><p>Enter percentages for protein, carbs, and fat.</p></section>`;
+        return;
+      }
+
+      if (proteinPercent < 0 || carbPercent < 0 || fatPercent < 0) {
+        resultEl.innerHTML = `<section class="card"><p>Custom percentages cannot be negative.</p></section>`;
+        return;
+      }
+
+      if (proteinPercent > 100 || carbPercent > 100 || fatPercent > 100) {
+        resultEl.innerHTML = `<section class="card"><p>Each macro percentage should be 100% or less.</p></section>`;
+        return;
+      }
+
+      if (total <= 0) {
+        resultEl.innerHTML = `<section class="card"><p>Custom macro percentages must add up to more than zero.</p></section>`;
+        return;
+      }
+
+      if (Math.abs(total - 100) > 0.5) {
+        resultEl.innerHTML = `<section class="card"><p>Custom macro percentages should total 100%. You're currently at ${total.toFixed(
+          1
+        )}%.</p></section>`;
+        return;
+      }
+
+      proteinPct = proteinPercent / 100;
+      carbPct = carbPercent / 100;
+      fatPct = fatPercent / 100;
+      splitLabel = `Custom split (${proteinPercent.toFixed(0)} / ${carbPercent.toFixed(0)} / ${fatPercent.toFixed(0)}%)`;
+    } else {
+      proteinPct = parseFloat(selectedOption?.dataset.protein || "0");
+      carbPct = parseFloat(selectedOption?.dataset.carbs || "0");
+      fatPct = parseFloat(selectedOption?.dataset.fat || "0");
+    }
+
+    if (
+      !Number.isFinite(proteinPct) ||
+      !Number.isFinite(carbPct) ||
+      !Number.isFinite(fatPct) ||
+      proteinPct + carbPct + fatPct <= 0
+    ) {
+      resultEl.innerHTML = `<section class="card"><p>Unable to read the macro split. Try choosing another option.</p></section>`;
+      return;
+    }
+
+    const weightKg = units === "imperial" ? weightVal * 0.45359237 : weightVal;
+    const weightLb = weightKg * 2.2046226218;
+
+    const proteinGrams = (caloriesVal * proteinPct) / 4;
+    const carbGrams = (caloriesVal * carbPct) / 4;
+    const fatGrams = (caloriesVal * fatPct) / 9;
+    const proteinPerKg = proteinGrams / weightKg;
+    const proteinPerLb = proteinGrams / weightLb;
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">${caloriesVal.toLocaleString()} kcal macro plan</h2>
+        <div class="stat-grid">
+          <div class="stat"><span class="label">Protein</span><span class="value">${formatMacro(
+            proteinGrams,
+            proteinPct
+          )}</span></div>
+          <div class="stat"><span class="label">Carbohydrates</span><span class="value">${formatMacro(
+            carbGrams,
+            carbPct
+          )}</span></div>
+          <div class="stat"><span class="label">Fats</span><span class="value">${formatMacro(
+            fatGrams,
+            fatPct
+          )}</span></div>
+          <div class="stat"><span class="label">Protein density</span><span class="value">${proteinPerKg.toFixed(
+            2
+          )} g/kg · ${proteinPerLb.toFixed(2)} g/lb</span></div>
+          <div class="stat"><span class="label">Macro split</span><span class="value">${splitLabel}</span></div>
+        </div>
+        <p class="helper" style="margin-top:12px;">Pair these targets with whole foods, fiber, and plenty of water. Reassess every few weeks based on gym performance and recovery.</p>
+      </section>
+    `;
+  });
+
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      updateUnits();
+      handleGoalChange();
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+
+  unitSelect.addEventListener("change", updateUnits);
+  goalSelect.addEventListener("change", handleGoalChange);
+  updateUnits();
+  handleGoalChange();
+})();

--- a/public/js/water-intake.js
+++ b/public/js/water-intake.js
@@ -1,0 +1,92 @@
+(function () {
+  const form = document.getElementById("water-form");
+  const resultEl = document.getElementById("water-result");
+  const unitSelect = document.getElementById("water-units");
+  const weightUnitEl = document.getElementById("water-weight-unit");
+  const weightInput = document.getElementById("water-weight");
+  const activityInput = document.getElementById("water-activity");
+  const climateSelect = document.getElementById("water-climate");
+
+  if (!form || !resultEl || !unitSelect || !weightUnitEl || !weightInput || !activityInput || !climateSelect) {
+    return;
+  }
+
+  const PLACEHOLDERS = { metric: "70", imperial: "154" };
+  const CLIMATE_FACTORS = {
+    temperate: 1,
+    warm: 1.1,
+    hot: 1.2,
+  };
+
+  function updateUnits() {
+    const unit = unitSelect.value === "imperial" ? "imperial" : "metric";
+    weightUnitEl.textContent = unit === "imperial" ? "(lb)" : "(kg)";
+    weightInput.placeholder = PLACEHOLDERS[unit];
+  }
+
+  function formatLiters(value) {
+    return `${value.toFixed(2)} L`;
+  }
+
+  function formatOunces(value) {
+    return `${value.toFixed(0)} oz`;
+  }
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+
+    const units = unitSelect.value === "imperial" ? "imperial" : "metric";
+    const weightVal = parseFloat(weightInput.value || "0");
+    const activityMinutes = parseFloat(activityInput.value || "0");
+    const climate = climateSelect.value;
+
+    if (!Number.isFinite(weightVal) || weightVal <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a body weight above zero.</p></section>`;
+      return;
+    }
+
+    if (!Number.isFinite(activityMinutes) || activityMinutes < 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter daily active minutes as zero or more.</p></section>`;
+      return;
+    }
+
+    const weightKg = units === "imperial" ? weightVal * 0.45359237 : weightVal;
+    const baseLiters = weightKg * 0.033;
+    const exerciseLiters = (activityMinutes / 30) * 0.35;
+    const multiplier = CLIMATE_FACTORS[climate] ?? 1;
+    const totalLiters = (baseLiters + exerciseLiters) * multiplier;
+    const adjustedBase = baseLiters + exerciseLiters;
+    const climateBonus = Math.max(0, totalLiters - adjustedBase);
+    const ounces = totalLiters * 33.8140226;
+    const cups = ounces / 8;
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">Suggested hydration: ${formatLiters(totalLiters)}</h2>
+        <div class="stat-grid">
+          <div class="stat"><span class="label">Base need</span><span class="value">${formatLiters(baseLiters)}</span><span class="helper" style="margin-top:6px;">≈33 ml × body weight (kg)</span></div>
+          <div class="stat"><span class="label">Exercise boost</span><span class="value">${formatLiters(
+            exerciseLiters
+          )}</span><span class="helper" style="margin-top:6px;">${activityMinutes.toFixed(0)} min active</span></div>
+          <div class="stat"><span class="label">Climate adjustment</span><span class="value">${formatLiters(
+            climateBonus
+          )}</span><span class="helper" style="margin-top:6px;">${multiplier.toFixed(2)}× multiplier</span></div>
+          <div class="stat"><span class="label">Daily target</span><span class="value">${formatLiters(
+            totalLiters
+          )}</span><span class="helper" style="margin-top:6px;">≈${formatOunces(ounces)} · ${cups.toFixed(1)} cups</span></div>
+        </div>
+        <p class="helper" style="margin-top:12px;">Sip steadily throughout the day and adjust upward on especially hard training days. Check with your doctor if you have fluid restrictions.</p>
+      </section>
+    `;
+  });
+
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      updateUnits();
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+
+  unitSelect.addEventListener("change", updateUnits);
+  updateUnits();
+})();

--- a/src/lib/calculatorData.ts
+++ b/src/lib/calculatorData.ts
@@ -168,4 +168,43 @@ export const calculatorCategories: CalculatorCategory[] = [
       },
     ],
   },
+  {
+    id: "health",
+    label: "Health & Fitness",
+    calculators: [
+      {
+        href: "/calculators/bmi-calculator",
+        name: "BMI Calculator",
+        navLabel: "BMI",
+        description: "Check your body mass index and see a healthy weight range for your height.",
+      },
+      {
+        href: "/calculators/bmr-calorie-calculator",
+        name: "BMR & Calorie Needs",
+        navLabel: "Calories",
+        description:
+          "Estimate daily calories for maintenance, weight loss, or muscle gain using the Mifflin-St Jeor equation.",
+      },
+      {
+        href: "/calculators/body-fat-estimator",
+        name: "Body Fat % Estimator",
+        navLabel: "Body Fat",
+        description:
+          "Approximate body fat percentage and lean mass from tape measurements using the U.S. Navy method.",
+      },
+      {
+        href: "/calculators/water-intake-calculator",
+        name: "Water Intake Guide",
+        navLabel: "Hydration",
+        description: "Find a daily water target based on body weight, activity, and climate.",
+      },
+      {
+        href: "/calculators/macros-calculator",
+        name: "Macros Calculator",
+        navLabel: "Macros",
+        description:
+          "Split your calorie goal into daily protein, carb, and fat targets for different training goals.",
+      },
+    ],
+  },
 ];

--- a/src/pages/calculators/bmi-calculator.astro
+++ b/src/pages/calculators/bmi-calculator.astro
@@ -1,0 +1,53 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "BMI Calculator";
+const description = "Check your body mass index and see a healthy weight range for your height.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/bmi-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Enter your height and weight to get a quick BMI screening plus the healthy weight range for your frame.
+      BMI is a starting point—muscle mass and body composition matter too.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="bmi-form">
+      <div class="form-grid">
+        <div>
+          <label for="bmi-units">Units</label>
+          <select id="bmi-units" name="units">
+            <option value="metric">Metric (kg, cm)</option>
+            <option value="imperial">Imperial (lb, in)</option>
+          </select>
+        </div>
+        <div>
+          <label for="bmi-height">Height <span class="muted" id="bmi-height-unit">(cm)</span></label>
+          <input id="bmi-height" name="height" type="number" min="0" step="0.1" placeholder="170" required />
+        </div>
+        <div>
+          <label for="bmi-weight">Weight <span class="muted" id="bmi-weight-unit">(kg)</span></label>
+          <input id="bmi-weight" name="weight" type="number" min="0" step="0.1" placeholder="70" required />
+        </div>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Calculate BMI</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">
+        Healthy weight guidelines are based on a BMI between 18.5 and 24.9 for adults.
+        Talk with your healthcare provider for personalized advice.
+      </p>
+    </form>
+  </section>
+
+  <section id="bmi-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="bmi-inline-1" />
+  <script defer src="/js/bmi-calculator.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/bmr-calorie-calculator.astro
+++ b/src/pages/calculators/bmr-calorie-calculator.astro
@@ -1,0 +1,75 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "BMR & Calorie Needs Calculator";
+const description =
+  "Estimate your basal metabolic rate and daily calorie targets using the Mifflin-St Jeor equation.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/bmr-calorie-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Find a personalized calorie range for maintaining, cutting, or building muscle.
+      The calculator uses the clinically trusted Mifflin-St Jeor formula for BMR.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="bmr-form">
+      <div class="form-grid">
+        <div>
+          <label for="bmr-gender">Sex</label>
+          <select id="bmr-gender" name="gender">
+            <option value="female">Female</option>
+            <option value="male">Male</option>
+          </select>
+        </div>
+        <div>
+          <label for="bmr-age">Age</label>
+          <input id="bmr-age" name="age" type="number" min="14" max="100" step="1" placeholder="30" required />
+        </div>
+        <div>
+          <label for="bmr-units">Units</label>
+          <select id="bmr-units" name="units">
+            <option value="metric">Metric (kg, cm)</option>
+            <option value="imperial">Imperial (lb, in)</option>
+          </select>
+        </div>
+        <div>
+          <label for="bmr-height">Height <span class="muted" id="bmr-height-unit">(cm)</span></label>
+          <input id="bmr-height" name="height" type="number" min="0" step="0.1" placeholder="170" required />
+        </div>
+        <div>
+          <label for="bmr-weight">Weight <span class="muted" id="bmr-weight-unit">(kg)</span></label>
+          <input id="bmr-weight" name="weight" type="number" min="0" step="0.1" placeholder="70" required />
+        </div>
+        <div>
+          <label for="bmr-activity">Activity level</label>
+          <select id="bmr-activity" name="activity">
+            <option value="1.2">Sedentary (little to no exercise)</option>
+            <option value="1.375">Lightly active (1–3 days/week)</option>
+            <option value="1.55">Moderately active (3–5 days/week)</option>
+            <option value="1.725">Very active (6–7 days/week)</option>
+            <option value="1.9">Athlete (twice daily training)</option>
+          </select>
+        </div>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Estimate calories</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">
+        Maintenance is calculated as BMR × activity factor. Calorie suggestions round to the nearest 10.
+        Always pair nutrition changes with guidance from your doctor or dietitian.
+      </p>
+    </form>
+  </section>
+
+  <section id="bmr-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="bmr-inline-1" />
+  <script defer src="/js/bmr-calorie.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/body-fat-estimator.astro
+++ b/src/pages/calculators/body-fat-estimator.astro
@@ -1,0 +1,73 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Body Fat Percentage Estimator";
+const description =
+  "Approximate your body fat percentage and lean mass using the U.S. Navy tape-measure method.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/body-fat-estimator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Grab a flexible tape and measure the sites below. The U.S. Navy formula uses circumferences to estimate body fat
+      percentage and lean mass.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="body-fat-form">
+      <div class="form-grid">
+        <div>
+          <label for="body-fat-sex">Sex</label>
+          <select id="body-fat-sex" name="sex">
+            <option value="male">Male</option>
+            <option value="female">Female</option>
+          </select>
+        </div>
+        <div>
+          <label for="body-fat-units">Units</label>
+          <select id="body-fat-units" name="units">
+            <option value="metric">Metric (kg, cm)</option>
+            <option value="imperial">Imperial (lb, in)</option>
+          </select>
+        </div>
+        <div>
+          <label for="body-fat-weight">Weight <span class="muted" id="body-fat-weight-unit">(kg)</span></label>
+          <input id="body-fat-weight" name="weight" type="number" min="0" step="0.1" placeholder="75" required />
+        </div>
+        <div>
+          <label for="body-fat-height">Height <span class="muted" id="body-fat-height-unit">(cm)</span></label>
+          <input id="body-fat-height" name="height" type="number" min="0" step="0.1" placeholder="175" required />
+        </div>
+        <div>
+          <label for="body-fat-neck">Neck <span class="muted" id="body-fat-neck-unit">(cm)</span></label>
+          <input id="body-fat-neck" name="neck" type="number" min="0" step="0.1" placeholder="38" required />
+        </div>
+        <div>
+          <label for="body-fat-waist">Waist (navel) <span class="muted" id="body-fat-waist-unit">(cm)</span></label>
+          <input id="body-fat-waist" name="waist" type="number" min="0" step="0.1" placeholder="85" required />
+        </div>
+        <div id="body-fat-hip-group">
+          <label for="body-fat-hip">Hip <span class="muted" id="body-fat-hip-unit">(cm)</span></label>
+          <input id="body-fat-hip" name="hip" type="number" min="0" step="0.1" placeholder="95" />
+        </div>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Estimate body fat</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">
+        Measure at the thickest points: neck just below the larynx, waist at the navel, hips around the widest glute
+        point. Keep the tape snug but not tight.
+      </p>
+    </form>
+  </section>
+
+  <section id="body-fat-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="body-fat-inline-1" />
+  <script defer src="/js/body-fat-estimator.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/macros-calculator.astro
+++ b/src/pages/calculators/macros-calculator.astro
@@ -1,0 +1,82 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Macros Calculator";
+const description =
+  "Convert a calorie target into daily protein, carbohydrate, and fat goals tailored to your training focus.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/macros-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Choose a macro split to see how many grams of protein, carbs, and fats you should aim for each day.
+      Use it alongside the BMR calculator to dial in your nutrition.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="macros-form">
+      <div class="form-grid">
+        <div>
+          <label for="macros-units">Weight units</label>
+          <select id="macros-units" name="units">
+            <option value="metric">Metric (kg)</option>
+            <option value="imperial">Imperial (lb)</option>
+          </select>
+        </div>
+        <div>
+          <label for="macros-weight">Body weight <span class="muted" id="macros-weight-unit">(kg)</span></label>
+          <input id="macros-weight" name="weight" type="number" min="0" step="0.1" placeholder="75" required />
+        </div>
+        <div>
+          <label for="macros-calories">Daily calories</label>
+          <input id="macros-calories" name="calories" type="number" min="800" step="10" placeholder="2200" required />
+        </div>
+        <div>
+          <label for="macro-goal">Macro split</label>
+          <select id="macro-goal" name="goal">
+            <option value="balanced" data-protein="0.3" data-carbs="0.4" data-fat="0.3">Balanced (30/40/30)</option>
+            <option value="fat-loss" data-protein="0.35" data-carbs="0.35" data-fat="0.3">Fat loss focus (35/35/30)</option>
+            <option value="muscle" data-protein="0.3" data-carbs="0.5" data-fat="0.2">Muscle gain focus (30/50/20)</option>
+            <option value="low-carb" data-protein="0.3" data-carbs="0.25" data-fat="0.45">Lower carb (30/25/45)</option>
+            <option value="custom">Custom percentages</option>
+          </select>
+        </div>
+      </div>
+
+      <div id="custom-macro-fields" style="display:none; margin-top:12px;">
+        <div class="form-grid columns-3">
+          <div>
+            <label for="macro-protein">Protein %</label>
+            <input id="macro-protein" name="protein" type="number" min="0" max="100" step="1" placeholder="30" />
+          </div>
+          <div>
+            <label for="macro-carbs">Carbs %</label>
+            <input id="macro-carbs" name="carbs" type="number" min="0" max="100" step="1" placeholder="40" />
+          </div>
+          <div>
+            <label for="macro-fat">Fat %</label>
+            <input id="macro-fat" name="fat" type="number" min="0" max="100" step="1" placeholder="30" />
+          </div>
+        </div>
+        <p class="helper" style="margin-top:8px;">Make sure the custom percentages add up to 100%.</p>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Break down macros</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">
+        Protein and carbs each contain 4 calories per gram. Fat contains 9 calories per gram. Adjust your split as your
+        goals evolve.
+      </p>
+    </form>
+  </section>
+
+  <section id="macros-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="macros-inline-1" />
+  <script defer src="/js/macros-calculator.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/water-intake-calculator.astro
+++ b/src/pages/calculators/water-intake-calculator.astro
@@ -1,0 +1,70 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Daily Water Intake Calculator";
+const description = "Estimate how much water to drink each day based on weight, exercise, and climate.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/water-intake-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Hydration needs change with body size and activity. Use this quick guide to translate your weight and daily
+      exercise into a reasonable water target.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="water-form">
+      <div class="form-grid columns-3">
+        <div>
+          <label for="water-units">Units</label>
+          <select id="water-units" name="units">
+            <option value="metric">Metric (kg)</option>
+            <option value="imperial">Imperial (lb)</option>
+          </select>
+        </div>
+        <div>
+          <label for="water-weight">Weight <span class="muted" id="water-weight-unit">(kg)</span></label>
+          <input id="water-weight" name="weight" type="number" min="0" step="0.1" placeholder="70" required />
+        </div>
+        <div>
+          <label for="water-activity">Active minutes</label>
+          <input
+            id="water-activity"
+            name="activity"
+            type="number"
+            min="0"
+            max="240"
+            step="5"
+            placeholder="30"
+            required
+          />
+        </div>
+        <div>
+          <label for="water-climate">Climate</label>
+          <select id="water-climate" name="climate">
+            <option value="temperate">Temperate / mostly indoors</option>
+            <option value="warm">Warm or humid</option>
+            <option value="hot">Hot climate or outdoor labor</option>
+          </select>
+        </div>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Calculate water target</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">
+        Baseline guidance is about 33 ml of water per kilogram of body weight. Add roughly 350 ml for every 30 minutes
+        of exercise, and more if you train in the heat.
+      </p>
+    </form>
+  </section>
+
+  <section id="water-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="water-inline-1" />
+  <script defer src="/js/water-intake.js"></script>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- add a Health & Fitness category with BMI, BMR, body fat, water intake, and macros tools
- implement Astro pages for each calculator with UI that matches the existing site
- add client-side logic for unit conversions, validations, and result summaries

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c95468f32c83238833d4061affc920