### PR TITLE
Add utility calculators for password, text, color, and QR code generation

### DIFF
--- a/public/js/hex-rgb-color-converter.js
+++ b/public/js/hex-rgb-color-converter.js
@@ -1,0 +1,195 @@
+(function () {
+  const form = document.getElementById("color-form");
+  const resultEl = document.getElementById("color-result");
+  const hexInput = document.getElementById("color-hex");
+  const rgbInput = document.getElementById("color-rgb");
+  const statusEl = document.getElementById("color-status");
+
+  if (!form || !resultEl || !hexInput || !rgbInput) return;
+
+  function setStatus(message) {
+    if (statusEl) {
+      statusEl.textContent = message;
+    }
+  }
+
+  function renderError(message) {
+    resultEl.innerHTML = `<section class="card"><p>${message}</p></section>`;
+    setStatus("");
+  }
+
+  function parseHex(value) {
+    if (!value) return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const match = trimmed.match(/^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/);
+    if (!match) return null;
+    let hex = match[1];
+    if (hex.length === 3) {
+      hex = hex
+        .split("")
+        .map((char) => char + char)
+        .join("");
+    }
+    const r = parseInt(hex.slice(0, 2), 16);
+    const g = parseInt(hex.slice(2, 4), 16);
+    const b = parseInt(hex.slice(4, 6), 16);
+    return { hex: `#${hex.toUpperCase()}`, r, g, b };
+  }
+
+  function parseRgb(value) {
+    if (!value) return null;
+    let text = value.trim();
+    if (!text) return null;
+    if (/^rgba?/i.test(text)) {
+      text = text.replace(/^rgba?\(/i, "").replace(/\)$/g, "");
+    }
+    const parts = text.split(/[\s,]+/).filter(Boolean);
+    if (parts.length < 3) return null;
+
+    const components = [];
+
+    for (let i = 0; i < 3; i += 1) {
+      const part = parts[i];
+      const isPercent = /%$/.test(part);
+      const numeric = parseFloat(part);
+      if (!Number.isFinite(numeric)) return null;
+      let value255;
+      if (isPercent) {
+        if (numeric < 0 || numeric > 100) return null;
+        value255 = Math.round((numeric / 100) * 255);
+      } else {
+        if (numeric < 0 || numeric > 255) return null;
+        value255 = Math.round(numeric);
+      }
+      components.push(value255);
+    }
+
+    return { r: components[0], g: components[1], b: components[2] };
+  }
+
+  function toHex(component) {
+    return component.toString(16).padStart(2, "0").toUpperCase();
+  }
+
+  function renderColor({ hex, r, g, b }) {
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">Color preview</h2>
+        <div class="color-preview">
+          <div class="color-swatch" style="background:${hex};"></div>
+          <div class="color-info">
+            <div class="color-row">
+              <span class="label">HEX</span>
+              <code data-role="hex-value"></code>
+              <button class="btn" type="button" data-copy="${hex}">Copy</button>
+            </div>
+            <div class="color-row">
+              <span class="label">RGB</span>
+              <code data-role="rgb-value"></code>
+              <button class="btn" type="button" data-copy="${r}, ${g}, ${b}">Copy</button>
+            </div>
+          </div>
+        </div>
+      </section>
+    `;
+
+    const hexValue = resultEl.querySelector('[data-role="hex-value"]');
+    const rgbValue = resultEl.querySelector('[data-role="rgb-value"]');
+    if (hexValue) {
+      hexValue.textContent = hex;
+    }
+    if (rgbValue) {
+      rgbValue.textContent = `${r}, ${g}, ${b}`;
+    }
+  }
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    setStatus("");
+    const hexValue = hexInput.value.trim();
+    const rgbValue = rgbInput.value.trim();
+
+    if (!hexValue && !rgbValue) {
+      renderError("Enter a hex code or RGB values to convert.");
+      return;
+    }
+
+    let color;
+    let message = "";
+
+    if (hexValue) {
+      color = parseHex(hexValue);
+      if (!color) {
+        renderError("Hex colors should be #RGB or #RRGGBB.");
+        return;
+      }
+      hexInput.value = color.hex;
+      rgbInput.value = `${color.r}, ${color.g}, ${color.b}`;
+      message = "Converted HEX → RGB.";
+    } else if (rgbValue) {
+      color = parseRgb(rgbValue);
+      if (!color) {
+        renderError("RGB values need three numbers between 0 and 255.");
+        return;
+      }
+      const hex = `#${toHex(color.r)}${toHex(color.g)}${toHex(color.b)}`;
+      hexInput.value = hex;
+      rgbInput.value = `${color.r}, ${color.g}, ${color.b}`;
+      color = { ...color, hex };
+      message = "Converted RGB → HEX.";
+    }
+
+    if (!color) {
+      renderError("We couldn't read that color. Try again.");
+      return;
+    }
+
+    renderColor(color);
+    setStatus(message);
+  });
+
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      resultEl.innerHTML = "";
+      setStatus("");
+    }, 0);
+  });
+
+  resultEl.addEventListener("click", async (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    const value = target.dataset.copy;
+    if (!value) return;
+
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(value);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = value;
+        temp.setAttribute("readonly", "true");
+        temp.style.position = "absolute";
+        temp.style.left = "-9999px";
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      const originalLabel = target.textContent;
+      target.textContent = "Copied!";
+      target.disabled = true;
+      setTimeout(() => {
+        target.textContent = originalLabel || "Copy";
+        target.disabled = false;
+      }, 1500);
+    } catch (error) {
+      target.textContent = "Copy failed";
+      target.disabled = true;
+      setTimeout(() => {
+        target.textContent = "Copy";
+        target.disabled = false;
+      }, 2000);
+    }
+  });
+})();

--- a/public/js/password-generator.js
+++ b/public/js/password-generator.js
@@ -1,0 +1,240 @@
+(function () {
+  const form = document.getElementById("password-form");
+  const resultEl = document.getElementById("password-result");
+  const lengthInput = document.getElementById("password-length");
+
+  if (!form || !resultEl || !lengthInput) return;
+
+  const LOWER = "abcdefghijklmnopqrstuvwxyz";
+  const UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  const NUMBERS = "0123456789";
+  const SYMBOLS = [
+    "!",
+    "@",
+    "#",
+    "$",
+    "%",
+    "^",
+    "&",
+    "*",
+    "(",
+    ")",
+    "-",
+    "_",
+    "=",
+    "+",
+    "[",
+    "]",
+    "{",
+    "}",
+    ";",
+    ":",
+    ",",
+    ".",
+    "<",
+    ">",
+    "?",
+    "/",
+    "|",
+    "~",
+    "`",
+    "'",
+    '"',
+    "\\",
+  ].join("");
+  const SIMILAR_CHARACTERS = new Set(["O", "0", "o", "1", "l", "I", "|", "\\"]);
+
+  function clampLength(value) {
+    if (!Number.isFinite(value)) return 16;
+    return Math.min(64, Math.max(4, Math.round(value)));
+  }
+
+  function secureRandom(max) {
+    if (max <= 0) return 0;
+    const cryptoObj = window.crypto || window.msCrypto;
+    if (cryptoObj && cryptoObj.getRandomValues) {
+      const array = new Uint32Array(1);
+      const limit = Math.floor(0xffffffff / max) * max;
+      let candidate = 0;
+      do {
+        cryptoObj.getRandomValues(array);
+        candidate = array[0];
+      } while (candidate >= limit);
+      return candidate % max;
+    }
+    return Math.floor(Math.random() * max);
+  }
+
+  function pickChar(pool) {
+    return pool.charAt(secureRandom(pool.length));
+  }
+
+  function filterSimilar(pool, avoidSimilar) {
+    if (!avoidSimilar) return pool;
+    return pool
+      .split("")
+      .filter((char) => !SIMILAR_CHARACTERS.has(char))
+      .join("");
+  }
+
+  function shuffle(array) {
+    for (let i = array.length - 1; i > 0; i -= 1) {
+      const j = secureRandom(i + 1);
+      const temp = array[i];
+      array[i] = array[j];
+      array[j] = temp;
+    }
+    return array;
+  }
+
+  function generatePassword(length, options) {
+    const pools = [];
+    const { useLower, useUpper, useNumbers, useSymbols, avoidSimilar } = options;
+
+    if (useLower) {
+      const filtered = filterSimilar(LOWER, avoidSimilar);
+      if (filtered) pools.push(filtered);
+    }
+    if (useUpper) {
+      const filtered = filterSimilar(UPPER, avoidSimilar);
+      if (filtered) pools.push(filtered);
+    }
+    if (useNumbers) {
+      const filtered = filterSimilar(NUMBERS, avoidSimilar);
+      if (filtered) pools.push(filtered);
+    }
+    if (useSymbols) {
+      const filtered = filterSimilar(SYMBOLS, avoidSimilar);
+      if (filtered) pools.push(filtered);
+    }
+
+    if (!pools.length) {
+      return { password: "", poolSize: 0 };
+    }
+
+    if (length < pools.length) {
+      return { password: "", poolSize: pools.reduce((sum, pool) => sum + pool.length, 0) };
+    }
+
+    const passwordChars = [];
+
+    // Ensure each selected pool contributes at least one character
+    for (const pool of pools) {
+      passwordChars.push(pickChar(pool));
+    }
+
+    const combinedLength = pools.reduce((sum, pool) => sum + pool.length, 0);
+
+    for (let i = passwordChars.length; i < length; i += 1) {
+      const pool = pools[secureRandom(pools.length)];
+      passwordChars.push(pickChar(pool));
+    }
+
+    shuffle(passwordChars);
+
+    return { password: passwordChars.join(""), poolSize: combinedLength };
+  }
+
+  function renderError(message) {
+    resultEl.innerHTML = `<section class="card"><p>${message}</p></section>`;
+  }
+
+  function renderPassword(password, poolSize, length) {
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">Generated password</h2>
+        <div class="password-display">
+          <input id="password-output" type="text" readonly spellcheck="false" />
+          <button class="btn" type="button" data-action="copy">Copy</button>
+        </div>
+        <p class="helper" id="password-meta"></p>
+      </section>
+    `;
+
+    const outputField = document.getElementById("password-output");
+    const meta = document.getElementById("password-meta");
+
+    if (outputField) {
+      outputField.value = password;
+      outputField.focus();
+      outputField.select();
+    }
+
+    if (meta) {
+      const entropy = poolSize > 0 ? (Math.log2(poolSize) * length).toFixed(1) : "0";
+      meta.textContent = `Character pool: ${poolSize} · Approximate entropy: ${entropy} bits.`;
+    }
+  }
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const useLower = form.lowercase.checked;
+    const useUpper = form.uppercase.checked;
+    const useNumbers = form.numbers.checked;
+    const useSymbols = form.symbols.checked;
+    const avoidSimilar = form.avoidSimilar.checked;
+    const length = clampLength(parseInt(form.length.value || "16", 10));
+
+    lengthInput.value = String(length);
+
+    if (!useLower && !useUpper && !useNumbers && !useSymbols) {
+      renderError("Select at least one character set before generating a password.");
+      return;
+    }
+
+    const { password, poolSize } = generatePassword(length, {
+      useLower,
+      useUpper,
+      useNumbers,
+      useSymbols,
+      avoidSimilar,
+    });
+
+    if (!password) {
+      renderError("Increase the length or adjust options so each set can be used.");
+      return;
+    }
+
+    renderPassword(password, poolSize, length);
+  });
+
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      lengthInput.value = "16";
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+
+  resultEl.addEventListener("click", async (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    if (target.dataset.action !== "copy") return;
+
+    const outputField = document.getElementById("password-output");
+    if (!(outputField instanceof HTMLInputElement)) return;
+
+    outputField.select();
+
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(outputField.value);
+      } else {
+        document.execCommand("copy");
+      }
+      const original = target.textContent;
+      target.textContent = "Copied!";
+      target.disabled = true;
+      setTimeout(() => {
+        target.textContent = original || "Copy";
+        target.disabled = false;
+      }, 1500);
+    } catch (error) {
+      target.textContent = "Copy failed";
+      target.disabled = true;
+      setTimeout(() => {
+        target.textContent = "Copy";
+        target.disabled = false;
+      }, 2000);
+    }
+  });
+})();

--- a/public/js/qr-code-generator.js
+++ b/public/js/qr-code-generator.js
@@ -1,0 +1,235 @@
+(function () {
+  const form = document.getElementById("qr-form");
+  const resultEl = document.getElementById("qr-result");
+  const input = document.getElementById("qr-input");
+  const sizeInput = document.getElementById("qr-size");
+  const eccInput = document.getElementById("qr-ecc");
+  const marginInput = document.getElementById("qr-margin");
+  const statusEl = document.getElementById("qr-status");
+
+  if (!form || !resultEl || !input || !sizeInput || !eccInput || !marginInput) return;
+
+  let activeController = null;
+  let objectUrl = null;
+  const ALLOWED_ECC = new Set(["L", "M", "Q", "H"]);
+
+  function setStatus(message) {
+    if (statusEl) {
+      statusEl.textContent = message;
+    }
+  }
+
+  function clearObjectUrl() {
+    if (objectUrl) {
+      URL.revokeObjectURL(objectUrl);
+      objectUrl = null;
+    }
+  }
+
+  function clearOutput() {
+    clearObjectUrl();
+    resultEl.innerHTML = "";
+    delete resultEl.dataset.qrRemote;
+    delete resultEl.dataset.qrText;
+  }
+
+  function showError(message) {
+    clearOutput();
+    resultEl.innerHTML = `<section class="card"><p>${message}</p></section>`;
+    setStatus("");
+  }
+
+  function clamp(value, min, max) {
+    if (!Number.isFinite(value)) return min;
+    return Math.min(max, Math.max(min, Math.round(value)));
+  }
+
+  function buildRemoteUrl(text, size, ecc, margin) {
+    const params = new URLSearchParams({
+      data: text,
+      size: `${size}x${size}`,
+      ecc,
+      margin: String(margin),
+      format: "png",
+    });
+    return `https://api.qrserver.com/v1/create-qr-code/?${params.toString()}`;
+  }
+
+  function renderQr({ displayUrl, downloadUrl, remoteUrl, text, size, fallback }) {
+    resultEl.dataset.qrRemote = remoteUrl;
+    resultEl.dataset.qrText = text;
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">QR code preview</h2>
+        <div class="qr-preview">
+          <img id="qr-image" alt="QR code preview" loading="lazy" />
+        </div>
+        <div class="qr-actions">
+          <a class="btn" id="qr-download" href="#">Download PNG</a>
+          <button class="btn" type="button" data-action="open">Open in new tab</button>
+          <button class="btn" type="button" data-action="copy-text">Copy original text</button>
+        </div>
+        <p class="helper" id="qr-helper"></p>
+      </section>
+    `;
+
+    const imageEl = document.getElementById("qr-image");
+    if (imageEl instanceof HTMLImageElement) {
+      imageEl.src = displayUrl;
+      imageEl.width = size;
+      imageEl.height = size;
+      imageEl.style.maxWidth = `${size}px`;
+      imageEl.style.width = "100%";
+      imageEl.style.height = "auto";
+      imageEl.decoding = "async";
+    }
+
+    const downloadLink = document.getElementById("qr-download");
+    if (downloadLink instanceof HTMLAnchorElement) {
+      downloadLink.href = downloadUrl;
+      downloadLink.textContent = fallback ? "Download / open PNG" : "Download PNG";
+      if (fallback) {
+        downloadLink.removeAttribute("download");
+        downloadLink.setAttribute("target", "_blank");
+        downloadLink.setAttribute("rel", "noopener");
+      } else {
+        downloadLink.setAttribute("download", "qr-code.png");
+        downloadLink.removeAttribute("target");
+        downloadLink.removeAttribute("rel");
+      }
+    }
+
+    const helper = document.getElementById("qr-helper");
+    if (helper) {
+      helper.textContent = fallback
+        ? "We fell back to the QR server preview—use the buttons to open or save it."
+        : "Download saves a PNG you can drop into a document or share immediately.";
+    }
+  }
+
+  async function fetchQr(remoteUrl, controller) {
+    try {
+      const response = await fetch(remoteUrl, { signal: controller.signal });
+      if (!response.ok) {
+        throw new Error(`Request failed: ${response.status}`);
+      }
+      const blob = await response.blob();
+      if (controller.signal.aborted) return null;
+      clearObjectUrl();
+      objectUrl = URL.createObjectURL(blob);
+      return { displayUrl: objectUrl, downloadUrl: objectUrl, remoteUrl, fallback: false };
+    } catch (error) {
+      if (controller.signal.aborted) {
+        return null;
+      }
+      return { displayUrl: remoteUrl, downloadUrl: remoteUrl, remoteUrl, fallback: true };
+    }
+  }
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const rawText = input.value.trim();
+    if (!rawText) {
+      showError("Enter some text or a link to build a QR code.");
+      return;
+    }
+
+    const eccValue = (eccInput.value || "M").toUpperCase();
+    const ecc = ALLOWED_ECC.has(eccValue) ? eccValue : "M";
+    let size = clamp(parseInt(sizeInput.value, 10), 120, 600);
+    let margin = clamp(parseInt(marginInput.value, 10), 0, 20);
+    sizeInput.value = String(size);
+    marginInput.value = String(margin);
+
+    const remoteUrl = buildRemoteUrl(rawText, size, ecc, margin);
+
+    if (activeController) {
+      activeController.abort();
+    }
+    const controller = new AbortController();
+    activeController = controller;
+
+    clearObjectUrl();
+    setStatus("Generating QR code…");
+    resultEl.innerHTML = `<section class="card"><p>Preparing your QR code…</p></section>`;
+
+    const data = await fetchQr(remoteUrl, controller);
+    if (!data) {
+      if (controller === activeController) {
+        activeController = null;
+        setStatus("");
+      }
+      return;
+    }
+
+    if (controller !== activeController) {
+      return;
+    }
+
+    renderQr({
+      ...data,
+      text: rawText,
+      size,
+    });
+
+    setStatus(data.fallback ? "Preview ready. Download opens in a new tab." : "QR code ready—download or share now.");
+    activeController = null;
+  });
+
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      if (activeController) {
+        activeController.abort();
+        activeController = null;
+      }
+      clearOutput();
+      setStatus("");
+    }, 0);
+  });
+
+  resultEl.addEventListener("click", async (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    const action = target.dataset.action;
+
+    if (action === "open") {
+      const remote = resultEl.dataset.qrRemote;
+      if (remote) {
+        window.open(remote, "_blank", "noopener");
+      }
+    } else if (action === "copy-text") {
+      const text = resultEl.dataset.qrText || "";
+      if (!text) return;
+      try {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          await navigator.clipboard.writeText(text);
+        } else {
+          const temp = document.createElement("textarea");
+          temp.value = text;
+          temp.setAttribute("readonly", "true");
+          temp.style.position = "absolute";
+          temp.style.left = "-9999px";
+          document.body.appendChild(temp);
+          temp.select();
+          document.execCommand("copy");
+          document.body.removeChild(temp);
+        }
+        const originalLabel = target.textContent;
+        target.textContent = "Copied!";
+        target.disabled = true;
+        setTimeout(() => {
+          target.textContent = originalLabel || "Copy";
+          target.disabled = false;
+        }, 1500);
+      } catch (error) {
+        target.textContent = "Copy failed";
+        target.disabled = true;
+        setTimeout(() => {
+          target.textContent = "Copy";
+          target.disabled = false;
+        }, 2000);
+      }
+    }
+  });
+})();

--- a/public/js/text-case-converter.js
+++ b/public/js/text-case-converter.js
@@ -1,0 +1,148 @@
+(function () {
+  const form = document.getElementById("case-form");
+  const resultEl = document.getElementById("case-result");
+  const input = document.getElementById("case-input");
+
+  if (!form || !resultEl || !input) return;
+
+  const LETTER_OR_NUMBER = /[\p{L}\p{N}]/u;
+
+  function toTitleCase(text) {
+    const lower = text.toLocaleLowerCase();
+    let result = "";
+    let capitalizeNext = true;
+
+    for (const char of lower) {
+      if (LETTER_OR_NUMBER.test(char)) {
+        if (capitalizeNext) {
+          result += char.toLocaleUpperCase();
+          capitalizeNext = false;
+        } else {
+          result += char;
+        }
+      } else {
+        result += char;
+        const isApostrophe = char === "'" || char === "\u2019";
+        capitalizeNext = !isApostrophe;
+      }
+    }
+
+    return result;
+  }
+
+  function formatModeLabel(mode) {
+    switch (mode) {
+      case "upper":
+        return "Uppercase";
+      case "lower":
+        return "Lowercase";
+      case "title":
+        return "Title Case";
+      default:
+        return "Converted";
+    }
+  }
+
+  function renderError(message) {
+    resultEl.innerHTML = `<section class="card"><p>${message}</p></section>`;
+  }
+
+  function renderResult(mode, text) {
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">${formatModeLabel(mode)}</h2>
+        <textarea id="case-output" readonly rows="8"></textarea>
+        <div style="margin-top:12px; display:flex; gap:10px; flex-wrap:wrap;">
+          <button class="btn" type="button" data-action="copy">Copy</button>
+          <button class="btn" type="button" data-action="replace">Replace input</button>
+        </div>
+        <p class="helper" id="case-meta"></p>
+      </section>
+    `;
+
+    const output = document.getElementById("case-output");
+    const meta = document.getElementById("case-meta");
+
+    if (output instanceof HTMLTextAreaElement) {
+      output.value = text;
+      output.scrollTop = 0;
+    }
+
+    if (meta) {
+      meta.textContent = `${text.length} character${text.length === 1 ? "" : "s"}.`;
+    }
+  }
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const submitter = event.submitter;
+    const mode = submitter && submitter instanceof HTMLButtonElement ? submitter.value : "upper";
+    const original = input.value;
+
+    if (!original) {
+      renderError("Enter or paste some text to convert.");
+      return;
+    }
+
+    let converted = original;
+
+    switch (mode) {
+      case "upper":
+        converted = original.toLocaleUpperCase();
+        break;
+      case "lower":
+        converted = original.toLocaleLowerCase();
+        break;
+      case "title":
+        converted = toTitleCase(original);
+        break;
+      default:
+        converted = original;
+    }
+
+    renderResult(mode, converted);
+  });
+
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+
+  resultEl.addEventListener("click", async (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+
+    const output = document.getElementById("case-output");
+    if (!(output instanceof HTMLTextAreaElement)) return;
+
+    if (target.dataset.action === "copy") {
+      output.select();
+      try {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          await navigator.clipboard.writeText(output.value);
+        } else {
+          document.execCommand("copy");
+        }
+        const originalLabel = target.textContent;
+        target.textContent = "Copied!";
+        target.disabled = true;
+        setTimeout(() => {
+          target.textContent = originalLabel || "Copy";
+          target.disabled = false;
+        }, 1500);
+      } catch (error) {
+        target.textContent = "Copy failed";
+        target.disabled = true;
+        setTimeout(() => {
+          target.textContent = "Copy";
+          target.disabled = false;
+        }, 2000);
+      }
+    } else if (target.dataset.action === "replace") {
+      input.value = output.value;
+      input.focus();
+      input.setSelectionRange(input.value.length, input.value.length);
+    }
+  });
+})();

--- a/src/lib/calculatorData.ts
+++ b/src/lib/calculatorData.ts
@@ -207,4 +207,34 @@ export const calculatorCategories: CalculatorCategory[] = [
       },
     ],
   },
+  {
+    id: "tools",
+    label: "Everyday Tools",
+    calculators: [
+      {
+        href: "/calculators/password-generator",
+        name: "Password Generator",
+        navLabel: "Password",
+        description: "Build strong random passwords with custom character sets and length.",
+      },
+      {
+        href: "/calculators/text-case-converter",
+        name: "Text Case Converter",
+        navLabel: "Text Case",
+        description: "Flip text to upper, lower, or title case without losing your formatting.",
+      },
+      {
+        href: "/calculators/hex-rgb-color-converter",
+        name: "Hex ↔ RGB Color Converter",
+        navLabel: "Color",
+        description: "Translate design colors between hexadecimal and RGB with a live swatch preview.",
+      },
+      {
+        href: "/calculators/qr-code-generator",
+        name: "QR Code Generator",
+        navLabel: "QR Code",
+        description: "Turn any text or link into a downloadable QR code with adjustable size.",
+      },
+    ],
+  },
 ];

--- a/src/pages/calculators/hex-rgb-color-converter.astro
+++ b/src/pages/calculators/hex-rgb-color-converter.astro
@@ -1,0 +1,45 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Hex ↔ RGB Color Converter";
+const description = "Convert brand colors between hexadecimal and RGB values with a live preview.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/hex-rgb-color-converter">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Designers and developers can translate colors either direction—enter a hex value or RGB triplet and we’ll fill in the
+      other format while previewing the swatch.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="color-form">
+      <div class="form-grid">
+        <div>
+          <label for="color-hex">Hex color</label>
+          <input id="color-hex" name="hex" type="text" placeholder="#4e8cff" autocapitalize="off" autocorrect="off" />
+          <p class="helper">Accepts #RGB or #RRGGBB.</p>
+        </div>
+        <div>
+          <label for="color-rgb">RGB color</label>
+          <input id="color-rgb" name="rgb" type="text" placeholder="78, 140, 255" autocapitalize="off" autocorrect="off" />
+          <p class="helper">Comma or space separated values (0 – 255).</p>
+        </div>
+      </div>
+
+      <div style="margin-top:16px; display:flex; gap:10px; flex-wrap:wrap; align-items:center;">
+        <button class="btn" type="submit">Convert</button>
+        <button class="btn" type="reset">Reset</button>
+        <span class="helper" id="color-status"></span>
+      </div>
+    </form>
+  </section>
+
+  <section id="color-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="color-inline-1" />
+  <script defer src="/js/hex-rgb-color-converter.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/password-generator.astro
+++ b/src/pages/calculators/password-generator.astro
@@ -1,0 +1,66 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Password Generator";
+const description = "Create strong passwords with adjustable length and character options.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/password-generator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Pick which characters to include and how long the password should be. Generate as many secure, random passwords as you
+      need and copy them with one click.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="password-form">
+      <div class="form-grid">
+        <div>
+          <label for="password-length">Password length</label>
+          <input id="password-length" name="length" type="number" min="4" max="64" value="16" required />
+          <p class="helper">Between 4 and 64 characters works well for most sites.</p>
+        </div>
+      </div>
+
+      <fieldset>
+        <legend>Character sets</legend>
+        <div class="option-grid">
+          <label class="option-tile">
+            <input id="password-lowercase" name="lowercase" type="checkbox" checked />
+            <span><strong>Lowercase</strong><br /><span class="helper">a – z</span></span>
+          </label>
+          <label class="option-tile">
+            <input id="password-uppercase" name="uppercase" type="checkbox" checked />
+            <span><strong>Uppercase</strong><br /><span class="helper">A – Z</span></span>
+          </label>
+          <label class="option-tile">
+            <input id="password-numbers" name="numbers" type="checkbox" checked />
+            <span><strong>Numbers</strong><br /><span class="helper">0 – 9</span></span>
+          </label>
+          <label class="option-tile">
+            <input id="password-symbols" name="symbols" type="checkbox" checked />
+            <span><strong>Symbols</strong><br /><span class="helper">! @ # $ % …</span></span>
+          </label>
+        </div>
+      </fieldset>
+
+      <label class="option-tile" style="margin-top:14px;">
+        <input id="password-avoid-similar" name="avoidSimilar" type="checkbox" />
+        <span><strong>Avoid similar characters</strong><br /><span class="helper">Skips O/0 and l/1 for clarity.</span></span>
+      </label>
+
+      <div style="margin-top:18px; display:flex; gap:10px; flex-wrap:wrap; align-items:center;">
+        <button class="btn" type="submit">Generate password</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+    </form>
+  </section>
+
+  <section id="password-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="password-inline-1" />
+  <script defer src="/js/password-generator.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/qr-code-generator.astro
+++ b/src/pages/calculators/qr-code-generator.astro
@@ -1,0 +1,55 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "QR Code Generator";
+const description = "Turn any text or URL into a ready-to-download QR code image.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/qr-code-generator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Paste a link, phrase, or Wi-Fi password and we’ll render a crisp PNG QR code. Adjust the size and error correction
+      level before downloading.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="qr-form">
+      <label for="qr-input">Text or link</label>
+      <textarea id="qr-input" name="text" placeholder="https://example.com" rows="4"></textarea>
+
+      <div class="form-grid" style="margin-top:12px;">
+        <div>
+          <label for="qr-size">Image size (pixels)</label>
+          <input id="qr-size" name="size" type="number" min="120" max="600" value="240" required />
+        </div>
+        <div>
+          <label for="qr-ecc">Error correction</label>
+          <select id="qr-ecc" name="ecc">
+            <option value="L">L – 7%</option>
+            <option value="M" selected>M – 15%</option>
+            <option value="Q">Q – 25%</option>
+            <option value="H">H – 30%</option>
+          </select>
+        </div>
+        <div>
+          <label for="qr-margin">Quiet zone (modules)</label>
+          <input id="qr-margin" name="margin" type="number" min="0" max="20" value="2" />
+        </div>
+      </div>
+
+      <div style="margin-top:18px; display:flex; gap:10px; flex-wrap:wrap; align-items:center;">
+        <button class="btn" type="submit">Generate QR code</button>
+        <button class="btn" type="reset">Reset</button>
+        <span class="helper" id="qr-status"></span>
+      </div>
+    </form>
+  </section>
+
+  <section id="qr-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="qr-inline-1" />
+  <script defer src="/js/qr-code-generator.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/text-case-converter.astro
+++ b/src/pages/calculators/text-case-converter.astro
@@ -1,0 +1,37 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Text Case Converter";
+const description = "Switch text between uppercase, lowercase, and title case instantly.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/text-case-converter">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Paste a sentence or paragraph and convert it to the casing you need. We keep your spacing and punctuation untouched so
+      you can drop the result right back into your document.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="case-form">
+      <label for="case-input">Your text</label>
+      <textarea id="case-input" name="text" placeholder="Paste or start typing here…" rows="8"></textarea>
+      <p class="helper">The original text stays in place—use the buttons to create a converted copy below.</p>
+
+      <div style="margin-top:16px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit" name="mode" value="upper">Uppercase</button>
+        <button class="btn" type="submit" name="mode" value="lower">Lowercase</button>
+        <button class="btn" type="submit" name="mode" value="title">Title Case</button>
+        <button class="btn" type="reset">Clear</button>
+      </div>
+    </form>
+  </section>
+
+  <section id="case-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="case-inline-1" />
+  <script defer src="/js/text-case-converter.js"></script>
+</BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -323,6 +323,147 @@ select {
   background: #0d1325;
   color: var(--text);
 }
+textarea {
+  width: 100%;
+  min-height: 120px;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: #0d1325;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 15px;
+  line-height: 1.5;
+  resize: vertical;
+}
+input[type="checkbox"],
+input[type="radio"] {
+  width: auto;
+  padding: 0;
+  margin: 0 8px 0 0;
+}
+fieldset {
+  border: none;
+  padding: 0;
+  margin: 12px 0 0;
+}
+legend {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+.option-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  margin-top: 8px;
+}
+.option-tile {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--panel-2);
+  color: var(--text);
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+  margin: 0;
+}
+.option-tile:hover,
+.option-tile:focus-within {
+  border-color: rgba(78, 140, 255, 0.45);
+  background: rgba(78, 140, 255, 0.08);
+}
+.option-tile input[type="checkbox"] {
+  margin: 0;
+  accent-color: var(--brand);
+}
+.option-tile strong {
+  display: block;
+  color: var(--text);
+  font-weight: 600;
+}
+.option-tile .helper {
+  display: block;
+  color: var(--muted);
+}
+.password-display {
+  margin-top: 12px;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.password-display input {
+  flex: 1 1 220px;
+}
+.color-preview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+}
+.color-swatch {
+  width: 86px;
+  height: 86px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: var(--panel-2);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+.color-info {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1 1 220px;
+}
+.color-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.color-row .label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.color-row code {
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--panel-2);
+  font-family: "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 14px;
+}
+.qr-preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--panel-2);
+}
+.qr-preview img {
+  width: 100%;
+  height: auto;
+  max-width: 360px;
+  image-rendering: pixelated;
+}
+.qr-actions {
+  margin-top: 14px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
 .date-input {
   position: relative;
 }


### PR DESCRIPTION
## Summary
- add an Everyday Tools navigation group with password, text case, color, and QR utilities
- build password generator, text transformer, hex/RGB converter, and QR code generator pages with supporting client logic
- extend shared styling for checkbox tiles, color previews, and QR download actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c95bde3dc88323842f91c77ece4c84