### PR TITLE
Add finance calculators for take-home pay, overtime, and investing

### DIFF
--- a/public/js/car-loan-affordability-calculator.js
+++ b/public/js/car-loan-affordability-calculator.js
@@ -1,0 +1,97 @@
+(function () {
+  const form = document.getElementById("car-form");
+  const resultEl = document.getElementById("car-result");
+
+  if (!form || !resultEl) return;
+
+  const currencyFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+
+  const numberFormatter = new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 2,
+  });
+
+  function handleSubmit(event) {
+    event.preventDefault();
+
+    const income = parseFloat(form.income.value || "0");
+    const debts = parseFloat(form.debts.value || "0");
+    const term = parseInt(form.term.value, 10);
+    const rate = parseFloat(form.rate.value || "0");
+    const down = parseFloat(form.down.value || "0");
+    const trade = parseFloat(form.trade.value || "0");
+    const share = parseFloat(form.share.value || "0");
+    const tax = parseFloat(form.tax.value || "0");
+
+    if (!Number.isFinite(income) || income <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter your gross annual income above zero.</p></section>`;
+      return;
+    }
+
+    if (!Number.isFinite(term) || term <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Select a valid loan term.</p></section>`;
+      return;
+    }
+
+    const monthlyIncome = income / 12;
+    const monthlyDebts = Number.isFinite(debts) && debts > 0 ? debts : 0;
+    const shareRate = Number.isFinite(share) && share > 0 ? share / 100 : 0.15;
+
+    let maxPayment = monthlyIncome * shareRate - monthlyDebts;
+    maxPayment = Math.max(0, maxPayment);
+
+    if (maxPayment <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Your existing monthly debt already uses the entire ${numberFormatter.format(shareRate * 100)}% target. Increase the target percentage or pay down other loans.</p></section>`;
+      return;
+    }
+
+    const monthlyRate = Number.isFinite(rate) && rate > 0 ? rate / 100 / 12 : 0;
+    let maxLoan = 0;
+    if (monthlyRate === 0) {
+      maxLoan = maxPayment * term;
+    } else {
+      const factor = 1 - Math.pow(1 + monthlyRate, -term);
+      if (factor <= 0) {
+        resultEl.innerHTML = `<section class="card"><p>Loan term is too short for the selected rate. Try a longer term.</p></section>`;
+        return;
+      }
+      maxLoan = (maxPayment * factor) / monthlyRate;
+    }
+
+    const upfrontCash = (Number.isFinite(down) && down > 0 ? down : 0) + (Number.isFinite(trade) && trade > 0 ? trade : 0);
+    const taxRate = Number.isFinite(tax) && tax > 0 ? tax / 100 : 0;
+    const priceBeforeTax = (maxLoan + upfrontCash) / (1 + taxRate);
+    const price = Math.max(0, priceBeforeTax);
+    const outTheDoor = price * (1 + taxRate);
+    const conservativePrice = price * 0.9;
+    const carShare = maxPayment / monthlyIncome;
+    const totalDebtRatio = (maxPayment + monthlyDebts) / monthlyIncome;
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">You can afford about ${currencyFormatter.format(price)} before tax</h2>
+        <div class="stat-grid">
+          <div class="stat"><span class="label">Monthly income</span><span class="value">${currencyFormatter.format(monthlyIncome)}</span></div>
+          <div class="stat"><span class="label">Target car payment</span><span class="value">${currencyFormatter.format(maxPayment)}</span></div>
+          <div class="stat"><span class="label">Loan amount</span><span class="value">${currencyFormatter.format(maxLoan)}</span></div>
+          <div class="stat"><span class="label">Out-the-door budget</span><span class="value">${currencyFormatter.format(outTheDoor)}</span></div>
+          <div class="stat"><span class="label">Upfront cash (down + trade)</span><span class="value">${currencyFormatter.format(upfrontCash)}</span></div>
+          <div class="stat"><span class="label">Car payment share of income</span><span class="value">${numberFormatter.format(carShare * 100)}%</span></div>
+          <div class="stat"><span class="label">Total debt-to-income</span><span class="value">${numberFormatter.format(totalDebtRatio * 100)}%</span></div>
+          <div class="stat"><span class="label">Cushioned car price (-10%)</span><span class="value">${currencyFormatter.format(conservativePrice)}</span></div>
+        </div>
+        <p class="helper" style="margin-top:12px;">Assumes a ${term}-month loan at ${numberFormatter.format(rate)}% APR. Adjust the target percentage to model more aggressive or conservative budgets.</p>
+      </section>
+    `;
+  }
+
+  form.addEventListener("submit", handleSubmit);
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+})();

--- a/public/js/credit-card-interest-calculator.js
+++ b/public/js/credit-card-interest-calculator.js
@@ -1,0 +1,195 @@
+(function () {
+  const form = document.getElementById("credit-form");
+  const resultEl = document.getElementById("credit-result");
+
+  if (!form || !resultEl) return;
+
+  const currencyFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+
+  const numberFormatter = new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 2,
+  });
+
+  function formatMonths(months) {
+    if (!Number.isFinite(months) || months <= 0) {
+      return "Already paid";
+    }
+    const years = Math.floor(months / 12);
+    const leftover = months % 12;
+    const parts = [];
+    if (years > 0) parts.push(`${years} yr${years > 1 ? "s" : ""}`);
+    if (leftover > 0) parts.push(`${leftover} mo${leftover > 1 ? "s" : ""}`);
+    return parts.join(" ") || "<1 mo";
+  }
+
+  function simulate(balance, rate, paymentAmount, charges, minFloor) {
+    let currentBalance = balance;
+    const monthlyRate = rate > 0 ? rate / 100 / 12 : 0;
+    const maxMonths = 600;
+    let months = 0;
+    let totalInterest = 0;
+    let totalPaid = 0;
+    let stalled = false;
+    let noProgress = 0;
+    let firstMonthInterest = 0;
+
+    while (months < maxMonths) {
+      if (currentBalance <= 0.01) break;
+      months += 1;
+      const startingBalance = currentBalance;
+      currentBalance += charges;
+      const interest = currentBalance * monthlyRate;
+      currentBalance += interest;
+      if (months === 1) firstMonthInterest = interest;
+      totalInterest += interest;
+
+      let payment = Math.max(paymentAmount, minFloor);
+      if (payment > currentBalance) payment = currentBalance;
+      currentBalance -= payment;
+      totalPaid += payment;
+
+      if (currentBalance >= startingBalance - 0.01 && interest + charges >= payment - 0.01) {
+        noProgress += 1;
+      } else {
+        noProgress = 0;
+      }
+
+      if (noProgress >= 6) {
+        stalled = true;
+        break;
+      }
+    }
+
+    if (currentBalance > 0.01 && months >= maxMonths) {
+      stalled = true;
+    }
+
+    return {
+      months,
+      totalInterest,
+      totalPaid,
+      stalled,
+      endingBalance: currentBalance,
+      firstMonthInterest,
+    };
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+
+    const balance = parseFloat(form.balance.value || "0");
+    const rate = parseFloat(form.rate.value || "0");
+    const payment = parseFloat(form.payment.value || "0");
+    const extra = parseFloat(form.extra.value || "0");
+    const charges = parseFloat(form.charges.value || "0");
+    const minimum = parseFloat(form.minimum.value || "0");
+
+    if (!Number.isFinite(balance) || balance <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter a credit card balance above zero.</p></section>`;
+      return;
+    }
+
+    if (!Number.isFinite(rate) || rate < 0) {
+      resultEl.innerHTML = `<section class="card"><p>APR must be zero or higher.</p></section>`;
+      return;
+    }
+
+    if (!Number.isFinite(payment) || payment <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Monthly payment must be greater than zero.</p></section>`;
+      return;
+    }
+
+    const basePayment = payment;
+    const withExtraPayment = payment + (Number.isFinite(extra) && extra > 0 ? extra : 0);
+    const monthlyCharges = Number.isFinite(charges) && charges > 0 ? charges : 0;
+    const floor = Number.isFinite(minimum) && minimum > 0 ? minimum : 0;
+
+    const currentPlan = simulate(balance, rate, basePayment, monthlyCharges, floor);
+    const extraPlan = simulate(balance, rate, withExtraPayment, monthlyCharges, floor);
+
+    const monthlyRate = rate > 0 ? rate / 100 / 12 : 0;
+    const firstMonthInterest = (balance + monthlyCharges) * monthlyRate;
+
+    const tableRows = [
+      {
+        label: "Current payment",
+        plan: currentPlan,
+        amount: basePayment,
+      },
+      {
+        label: withExtraPayment === basePayment ? "With current payment" : "With extra payment",
+        plan: extraPlan,
+        amount: withExtraPayment,
+      },
+    ];
+
+    const summaryRows = tableRows
+      .map((row) => {
+        const payoff = row.plan.stalled ? "Not paid off" : formatMonths(row.plan.months);
+        const interest = currencyFormatter.format(row.plan.totalInterest);
+        const totalPaid = currencyFormatter.format(row.plan.totalPaid);
+        return `<tr><td>${row.label}</td><td>${currencyFormatter.format(row.amount)}</td><td>${payoff}</td><td>${interest}</td><td>${totalPaid}</td></tr>`;
+      })
+      .join("");
+
+    let comparison = "Paying extra each month doesn't change the payoff because no additional payment was entered.";
+    if (withExtraPayment !== basePayment) {
+      if (extraPlan.stalled) {
+        comparison = "Even with the extra payment, the balance doesn't shrink—raise the payment or stop new charges.";
+      } else if (currentPlan.stalled) {
+        comparison = "Adding the extra payment is enough to reverse the balance and pay the card off.";
+      } else {
+        const monthsSaved = currentPlan.months - extraPlan.months;
+        const interestSaved = currentPlan.totalInterest - extraPlan.totalInterest;
+        comparison = `Extra payments save ${currencyFormatter.format(interestSaved)} in interest and cut ${
+          monthsSaved > 0 ? `${monthsSaved} months from the payoff timeline` : "no time from the payoff timeline"
+        }.`;
+      }
+    }
+
+    const balanceTrend = currentPlan.stalled
+      ? `With your current payment, the balance grows to ${currencyFormatter.format(currentPlan.endingBalance)} after about ${
+          currentPlan.months
+        } months.`
+      : "";
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">Credit card payoff outlook</h2>
+        <div class="stat-grid">
+          <div class="stat"><span class="label">Starting balance</span><span class="value">${currencyFormatter.format(balance)}</span></div>
+          <div class="stat"><span class="label">APR</span><span class="value">${numberFormatter.format(rate)}%</span></div>
+          <div class="stat"><span class="label">First month interest</span><span class="value">${currencyFormatter.format(firstMonthInterest)}</span></div>
+          <div class="stat"><span class="label">Monthly charges added</span><span class="value">${currencyFormatter.format(monthlyCharges)}</span></div>
+          <div class="stat"><span class="label">Payment floor</span><span class="value">${currencyFormatter.format(floor)}</span></div>
+        </div>
+        <div class="table-wrap" style="margin-top:18px;">
+          <table>
+            <thead>
+              <tr>
+                <th>Scenario</th>
+                <th>Monthly payment</th>
+                <th>Payoff timeline</th>
+                <th>Total interest</th>
+                <th>Total paid</th>
+              </tr>
+            </thead>
+            <tbody>${summaryRows}</tbody>
+          </table>
+        </div>
+        <p class="helper" style="margin-top:12px;">${comparison} ${balanceTrend}</p>
+      </section>
+    `;
+  }
+
+  form.addEventListener("submit", handleSubmit);
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+})();

--- a/public/js/debt-payoff-calculator.js
+++ b/public/js/debt-payoff-calculator.js
@@ -1,0 +1,394 @@
+(function () {
+  const form = document.getElementById("debt-form");
+  const resultEl = document.getElementById("debt-result");
+  const rowsContainer = document.getElementById("debt-rows");
+  const addDebtButton = document.getElementById("add-debt");
+
+  if (!form || !resultEl || !rowsContainer || !addDebtButton) return;
+
+  const currencyFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+
+  const numberFormatter = new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 2,
+  });
+
+  function createDebtRow(initial = {}) {
+    const index = rowsContainer.children.length + 1;
+    const wrapper = document.createElement("div");
+    wrapper.dataset.debtRow = "true";
+    wrapper.style.border = "1px solid var(--border)";
+    wrapper.style.borderRadius = "12px";
+    wrapper.style.padding = "12px";
+    wrapper.style.background = "var(--panel-2)";
+
+    const grid = document.createElement("div");
+    grid.className = "form-grid";
+
+    const nameField = document.createElement("div");
+    nameField.innerHTML = `
+      <label>Debt name</label>
+      <input type="text" data-field="name" placeholder="Debt ${index}" value="${initial.name || ""}" />
+    `;
+
+    const balanceField = document.createElement("div");
+    balanceField.innerHTML = `
+      <label>Balance</label>
+      <input type="number" data-field="balance" min="0" step="1" placeholder="4500" value="${
+        initial.balance !== undefined ? initial.balance : ""
+      }" />
+    `;
+
+    const rateField = document.createElement("div");
+    rateField.innerHTML = `
+      <label>APR (%)</label>
+      <input type="number" data-field="rate" min="0" step="0.01" placeholder="18.5" value="${
+        initial.rate !== undefined ? initial.rate : ""
+      }" />
+    `;
+
+    const paymentField = document.createElement("div");
+    paymentField.innerHTML = `
+      <label>Minimum payment</label>
+      <input type="number" data-field="payment" min="0" step="1" placeholder="150" value="${
+        initial.payment !== undefined ? initial.payment : ""
+      }" />
+    `;
+
+    grid.appendChild(nameField);
+    grid.appendChild(balanceField);
+    grid.appendChild(rateField);
+    grid.appendChild(paymentField);
+
+    const removeButton = document.createElement("button");
+    removeButton.type = "button";
+    removeButton.textContent = "Remove";
+    removeButton.className = "btn";
+    removeButton.style.marginTop = "12px";
+    removeButton.addEventListener("click", () => {
+      if (rowsContainer.children.length > 1) {
+        wrapper.remove();
+      } else {
+        Array.from(wrapper.querySelectorAll("input")).forEach((input) => {
+          input.value = "";
+        });
+      }
+    });
+
+    wrapper.appendChild(grid);
+    wrapper.appendChild(removeButton);
+    return wrapper;
+  }
+
+  function ensureRows() {
+    if (rowsContainer.children.length === 0) {
+      rowsContainer.appendChild(
+        createDebtRow({ name: "Credit Card", balance: 6500, rate: 19.99, payment: 175 })
+      );
+      rowsContainer.appendChild(
+        createDebtRow({ name: "Auto Loan", balance: 13000, rate: 6.5, payment: 325 })
+      );
+    }
+  }
+
+  ensureRows();
+
+  addDebtButton.addEventListener("click", () => {
+    rowsContainer.appendChild(createDebtRow());
+  });
+
+  function parseDebts() {
+    const rows = Array.from(rowsContainer.querySelectorAll("[data-debt-row]"));
+    const debts = [];
+
+    for (let i = 0; i < rows.length; i += 1) {
+      const row = rows[i];
+      const nameInput = row.querySelector('[data-field="name"]');
+      const balanceInput = row.querySelector('[data-field="balance"]');
+      const rateInput = row.querySelector('[data-field="rate"]');
+      const paymentInput = row.querySelector('[data-field="payment"]');
+
+      const balance = parseFloat(balanceInput?.value || "0");
+      const rate = parseFloat(rateInput?.value || "0");
+      const payment = parseFloat(paymentInput?.value || "0");
+
+      if (!Number.isFinite(balance) || balance <= 0) {
+        continue;
+      }
+
+      if (!Number.isFinite(rate) || rate < 0) {
+        throw new Error("Interest rates must be zero or positive.");
+      }
+
+      if (!Number.isFinite(payment) || payment <= 0) {
+        throw new Error("Minimum payments must be above zero.");
+      }
+
+      debts.push({
+        name: nameInput?.value?.trim() || `Debt ${i + 1}`,
+        balance,
+        rate,
+        minPayment: payment,
+      });
+    }
+
+    if (debts.length === 0) {
+      throw new Error("Please enter at least one debt with a positive balance.");
+    }
+
+    return debts;
+  }
+
+  function orderDebts(debts, method) {
+    const active = debts.filter((debt) => debt.balance > 0.01);
+    if (method === "avalanche") {
+      active.sort((a, b) => {
+        if (b.rate !== a.rate) return b.rate - a.rate;
+        return a.balance - b.balance;
+      });
+    } else {
+      active.sort((a, b) => {
+        if (Math.abs(a.balance - b.balance) > 0.01) return a.balance - b.balance;
+        return b.rate - a.rate;
+      });
+    }
+    return active;
+  }
+
+  function simulatePayoff(debts, method, extraPayment) {
+    const clones = debts.map((debt) => ({
+      name: debt.name,
+      balance: debt.balance,
+      rate: debt.rate,
+      minPayment: debt.minPayment,
+      totalPaid: 0,
+      interestPaid: 0,
+    }));
+
+    const history = [];
+    let months = 0;
+    const maxMonths = 600; // 50 years cap
+    let stalled = false;
+    let noProgressMonths = 0;
+
+    while (months < maxMonths) {
+      const remainingBalance = clones.reduce((sum, debt) => sum + Math.max(0, debt.balance), 0);
+      if (remainingBalance <= 0.01) break;
+
+      months += 1;
+      let monthInterest = 0;
+
+      for (const debt of clones) {
+        if (debt.balance <= 0) continue;
+        const interest = (debt.balance * debt.rate) / 100 / 12;
+        debt.balance += interest;
+        debt.interestPaid += interest;
+        monthInterest += interest;
+      }
+
+      let available = extraPayment;
+      let monthPayment = 0;
+
+      for (const debt of clones) {
+        if (debt.balance <= 0) continue;
+        const minPay = Math.min(debt.minPayment, debt.balance);
+        if (minPay > 0) {
+          debt.balance -= minPay;
+          debt.totalPaid += minPay;
+          monthPayment += minPay;
+          if (debt.balance < 0) {
+            available += -debt.balance;
+            debt.balance = 0;
+          }
+        }
+      }
+
+      available = Math.max(available, 0);
+
+      while (available > 0.01) {
+        const targets = orderDebts(clones, method);
+        if (targets.length === 0) break;
+        const target = targets[0];
+        const pay = Math.min(available, target.balance);
+        target.balance -= pay;
+        target.totalPaid += pay;
+        monthPayment += pay;
+        available -= pay;
+        if (target.balance < 0) {
+          available += -target.balance;
+          target.balance = 0;
+        }
+      }
+
+      const newBalance = clones.reduce((sum, debt) => sum + Math.max(0, debt.balance), 0);
+      history.push({ month: months, balance: newBalance, payment: monthPayment, interest: monthInterest });
+
+      if (newBalance >= remainingBalance - 0.01 && monthInterest >= monthPayment - 0.01) {
+        noProgressMonths += 1;
+      } else {
+        noProgressMonths = 0;
+      }
+
+      if (noProgressMonths >= 6) {
+        stalled = true;
+        break;
+      }
+    }
+
+    const remaining = clones.reduce((sum, debt) => sum + Math.max(0, debt.balance), 0);
+    if (remaining > 0.01) {
+      stalled = true;
+    }
+
+    const totalPaid = clones.reduce((sum, debt) => sum + debt.totalPaid, 0);
+    const totalInterest = clones.reduce((sum, debt) => sum + debt.interestPaid, 0);
+
+    return { months, totalPaid, totalInterest, history, debts: clones, stalled, remaining };
+  }
+
+  function formatMonths(months) {
+    if (!Number.isFinite(months) || months <= 0) {
+      return "Already paid";
+    }
+    const years = Math.floor(months / 12);
+    const leftover = months % 12;
+    const parts = [];
+    if (years > 0) parts.push(`${years} yr${years > 1 ? "s" : ""}`);
+    if (leftover > 0) parts.push(`${leftover} mo${leftover > 1 ? "s" : ""}`);
+    return parts.join(" ") || "<1 mo";
+  }
+
+  function payoffDate(startValue, months) {
+    if (!startValue) return "—";
+    const [year, month] = startValue.split("-").map((part) => parseInt(part, 10));
+    if (!Number.isFinite(year) || !Number.isFinite(month)) return "—";
+    const date = new Date(year, month - 1, 1);
+    date.setMonth(date.getMonth() + months);
+    return date.toLocaleDateString("en-US", { month: "long", year: "numeric" });
+  }
+
+  function buildDebtTable(methodResult) {
+    const rows = methodResult.debts
+      .map((debt) => {
+        return `<tr><td>${debt.name}</td><td>${currencyFormatter.format(debt.totalPaid)}</td><td>${currencyFormatter.format(debt.interestPaid)}</td></tr>`;
+      })
+      .join("");
+
+    return `
+      <div class="table-wrap" style="margin-top:18px;">
+        <table>
+          <thead>
+            <tr>
+              <th>Debt</th>
+              <th>Total paid</th>
+              <th>Interest paid</th>
+            </tr>
+          </thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+
+    let debts;
+    try {
+      debts = parseDebts();
+    } catch (error) {
+      resultEl.innerHTML = `<section class="card"><p>${error.message}</p></section>`;
+      return;
+    }
+
+    const extra = parseFloat(form.extra.value || "0");
+    const extraPayment = Number.isFinite(extra) && extra > 0 ? extra : 0;
+    const startMonth = form.start.value;
+
+    const snowball = simulatePayoff(debts, "snowball", extraPayment);
+    const avalanche = simulatePayoff(debts, "avalanche", extraPayment);
+
+    const minimums = debts.reduce((sum, debt) => sum + debt.minPayment, 0);
+    const budget = minimums + extraPayment;
+
+    const snowballTimeline = snowball.stalled ? "Not paid off" : formatMonths(snowball.months);
+    const avalancheTimeline = avalanche.stalled ? "Not paid off" : formatMonths(avalanche.months);
+
+    const snowballDate = snowball.stalled ? "—" : payoffDate(startMonth, snowball.months);
+    const avalancheDate = avalanche.stalled ? "—" : payoffDate(startMonth, avalanche.months);
+
+    const interestDifference = snowball.totalInterest - avalanche.totalInterest;
+    const recommendation = snowball.stalled
+      ? "Minimum payments and extra cash aren't enough to pay off the debts. Increase the budget or negotiate lower rates."
+      : avalanche.stalled
+      ? "Avalanche results couldn't pay off the debts with the current budget."
+      : interestDifference > 0
+      ? `Avalanche saves ${currencyFormatter.format(interestDifference)} in interest versus snowball.`
+      : interestDifference < 0
+      ? `Snowball costs ${currencyFormatter.format(Math.abs(interestDifference))} less interest than avalanche.`
+      : "Both methods cost the same in interest with this debt mix.";
+
+    const totalBalance = debts.reduce((sum, debt) => sum + debt.balance, 0);
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">Debt-free game plan</h2>
+        <div class="stat-grid">
+          <div class="stat"><span class="label">Starting balance</span><span class="value">${currencyFormatter.format(totalBalance)}</span></div>
+          <div class="stat"><span class="label">Minimum payments</span><span class="value">${currencyFormatter.format(minimums)}</span></div>
+          <div class="stat"><span class="label">Extra payment</span><span class="value">${currencyFormatter.format(extraPayment)}</span></div>
+          <div class="stat"><span class="label">Monthly budget</span><span class="value">${currencyFormatter.format(budget)}</span></div>
+          <div class="stat"><span class="label">Snowball timeline</span><span class="value">${snowballTimeline}</span></div>
+          <div class="stat"><span class="label">Avalanche timeline</span><span class="value">${avalancheTimeline}</span></div>
+          <div class="stat"><span class="label">Snowball interest</span><span class="value">${currencyFormatter.format(snowball.totalInterest)}</span></div>
+          <div class="stat"><span class="label">Avalanche interest</span><span class="value">${currencyFormatter.format(avalanche.totalInterest)}</span></div>
+        </div>
+        <div class="table-wrap" style="margin-top:18px;">
+          <table>
+            <thead>
+              <tr>
+                <th>Method</th>
+                <th>Months</th>
+                <th>Interest paid</th>
+                <th>Total paid</th>
+                <th>Payoff date</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Snowball</td>
+                <td>${snowball.stalled ? "—" : snowball.months}</td>
+                <td>${currencyFormatter.format(snowball.totalInterest)}</td>
+                <td>${currencyFormatter.format(snowball.totalPaid)}</td>
+                <td>${snowballDate}</td>
+              </tr>
+              <tr>
+                <td>Avalanche</td>
+                <td>${avalanche.stalled ? "—" : avalanche.months}</td>
+                <td>${currencyFormatter.format(avalanche.totalInterest)}</td>
+                <td>${currencyFormatter.format(avalanche.totalPaid)}</td>
+                <td>${avalancheDate}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="helper" style="margin-top:12px;">${recommendation}</p>
+        <h3 style="margin-top:18px;">Snowball payoff by account</h3>
+        ${buildDebtTable(snowball)}
+        <h3 style="margin-top:18px;">Avalanche payoff by account</h3>
+        ${buildDebtTable(avalanche)}
+      </section>
+    `;
+  }
+
+  form.addEventListener("submit", handleSubmit);
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      resultEl.innerHTML = "";
+      ensureRows();
+    }, 0);
+  });
+})();

--- a/public/js/freelancer-hourly-rate-calculator.js
+++ b/public/js/freelancer-hourly-rate-calculator.js
@@ -1,0 +1,125 @@
+(function () {
+  const form = document.getElementById("freelance-form");
+  const resultEl = document.getElementById("freelance-result");
+
+  if (!form || !resultEl) return;
+
+  const currencyFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+
+  const numberFormatter = new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 2,
+  });
+
+  function handleSubmit(event) {
+    event.preventDefault();
+
+    const income = parseFloat(form.income.value || "0");
+    const expenses = parseFloat(form.expenses.value || "0");
+    const hours = parseFloat(form.hours.value || "0");
+    const weeksOff = parseFloat(form.weeksOff.value || "0");
+    const marginPercent = parseFloat(form.margin.value || "0");
+    const reservePercent = parseFloat(form.reserve.value || "0");
+    const projectHours = parseFloat(form.projectHours.value || "0");
+    const projectExpenses = parseFloat(form.projectExpenses.value || "0");
+
+    if (!Number.isFinite(income) || income <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Enter the annual take-home pay you want from freelancing.</p></section>`;
+      return;
+    }
+
+    if (!Number.isFinite(hours) || hours <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Billable hours per week must be greater than zero.</p></section>`;
+      return;
+    }
+
+    const safeWeeksOff = Number.isFinite(weeksOff) && weeksOff > 0 ? weeksOff : 0;
+    const workingWeeks = 52 - safeWeeksOff;
+
+    if (workingWeeks <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Leave at least one working week in the year.</p></section>`;
+      return;
+    }
+
+    const annualBillableHours = hours * workingWeeks;
+    if (annualBillableHours <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>We need some billable hours to calculate a rate.</p></section>`;
+      return;
+    }
+
+    const expensesAnnual = Number.isFinite(expenses) && expenses > 0 ? expenses : 0;
+    const marginRate = Number.isFinite(marginPercent) && marginPercent > 0 ? marginPercent / 100 : 0;
+    const reserveRate = Number.isFinite(reservePercent) && reservePercent > 0 ? reservePercent / 100 : 0;
+
+    if (reserveRate >= 1) {
+      resultEl.innerHTML = `<section class="card"><p>The reserve percentage must be below 100%.</p></section>`;
+      return;
+    }
+
+    const baseCost = income + expensesAnnual;
+    const revenueToCoverReserve = reserveRate > 0 ? baseCost / (1 - reserveRate) : baseCost;
+    const recommendedRevenue = revenueToCoverReserve * (1 + marginRate);
+
+    const breakevenHourly = revenueToCoverReserve / annualBillableHours;
+    const recommendedHourly = recommendedRevenue / annualBillableHours;
+    const dayRate = recommendedHourly * 8;
+    const monthRate = recommendedHourly * hours * 4.33;
+
+    const reserveDollars = recommendedRevenue * reserveRate;
+    const estimatedTakeHome = recommendedRevenue - reserveDollars - expensesAnnual;
+
+    let projectMarkup = "";
+    if (Number.isFinite(projectHours) && projectHours > 0) {
+      const projectCost = recommendedHourly * projectHours;
+      const projectExpense = Number.isFinite(projectExpenses) && projectExpenses > 0 ? projectExpenses : 0;
+      const projectTotal = projectCost + projectExpense;
+      const baseProjectTotal = breakevenHourly * projectHours + projectExpense;
+      projectMarkup = `
+        <div class="table-wrap" style="margin-top:18px;">
+          <table>
+            <thead>
+              <tr>
+                <th>Project estimate</th>
+                <th>Amount</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td>Hours @ recommended rate (${currencyFormatter.format(recommendedHourly)})</td><td>${currencyFormatter.format(projectCost)}</td></tr>
+              <tr><td>Expenses</td><td>${currencyFormatter.format(projectExpense)}</td></tr>
+              <tr><td><strong>Suggested quote</strong></td><td><strong>${currencyFormatter.format(projectTotal)}</strong></td></tr>
+              <tr><td>Quote to just break even</td><td>${currencyFormatter.format(baseProjectTotal)}</td></tr>
+            </tbody>
+          </table>
+        </div>
+      `;
+    }
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">Charge about ${currencyFormatter.format(recommendedHourly)} per billable hour</h2>
+        <div class="stat-grid">
+          <div class="stat"><span class="label">Annual billable hours</span><span class="value">${numberFormatter.format(annualBillableHours)}</span></div>
+          <div class="stat"><span class="label">Base hourly (covers goals)</span><span class="value">${currencyFormatter.format(breakevenHourly)}</span></div>
+          <div class="stat"><span class="label">Recommended hourly</span><span class="value">${currencyFormatter.format(recommendedHourly)}</span></div>
+          <div class="stat"><span class="label">Day rate (8 hrs)</span><span class="value">${currencyFormatter.format(dayRate)}</span></div>
+          <div class="stat"><span class="label">Monthly retainer*</span><span class="value">${currencyFormatter.format(monthRate)}</span></div>
+          <div class="stat"><span class="label">Reserve set aside</span><span class="value">${currencyFormatter.format(reserveDollars)}</span></div>
+          <div class="stat"><span class="label">Target revenue</span><span class="value">${currencyFormatter.format(recommendedRevenue)}</span></div>
+          <div class="stat"><span class="label">Est. take-home after reserve</span><span class="value">${currencyFormatter.format(estimatedTakeHome)}</span></div>
+        </div>
+        <p class="helper" style="margin-top:12px;">*Monthly retainer assumes ${numberFormatter.format(hours)} billable hours each week (${numberFormatter.format(hours * 4.33)} hours per month).</p>
+        ${projectMarkup}
+      </section>
+    `;
+  }
+
+  form.addEventListener("submit", handleSubmit);
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+})();

--- a/public/js/overtime-pay-calculator.js
+++ b/public/js/overtime-pay-calculator.js
@@ -1,0 +1,106 @@
+(function () {
+  const form = document.getElementById("overtime-form");
+  const resultEl = document.getElementById("overtime-result");
+
+  if (!form || !resultEl) return;
+
+  const currencyFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+
+  const numberFormatter = new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 2,
+  });
+
+  function handleSubmit(event) {
+    event.preventDefault();
+
+    const rate = parseFloat(form.rate.value || "0");
+    const regularHours = parseFloat(form.regularHours.value || "0");
+    const overtimeHours = parseFloat(form.overtimeHours.value || "0");
+    const multiplier = parseFloat(form.multiplier.value || "1.5");
+    const doubleHours = parseFloat(form.doubleHours.value || "0");
+    const bonus = parseFloat(form.bonus.value || "0");
+
+    if (!Number.isFinite(rate) || rate <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Please enter a base hourly rate above zero.</p></section>`;
+      return;
+    }
+
+    if (!Number.isFinite(regularHours) || regularHours < 0) {
+      resultEl.innerHTML = `<section class="card"><p>Regular hours cannot be negative.</p></section>`;
+      return;
+    }
+
+    const otHours = Number.isFinite(overtimeHours) && overtimeHours > 0 ? overtimeHours : 0;
+    const otMultiplier = Number.isFinite(multiplier) && multiplier >= 1 ? multiplier : 1.5;
+    const dblHours = Number.isFinite(doubleHours) && doubleHours > 0 ? doubleHours : 0;
+    const flatBonus = Number.isFinite(bonus) && bonus > 0 ? bonus : 0;
+
+    const totalHours = regularHours + otHours + dblHours;
+    if (totalHours <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Add at least one hour of work to calculate pay.</p></section>`;
+      return;
+    }
+
+    const regularPay = rate * regularHours;
+    const overtimeBase = rate * otHours;
+    const overtimePremium = rate * Math.max(otMultiplier - 1, 0) * otHours;
+    const doubleBase = rate * dblHours;
+    const doublePremium = rate * dblHours; // double time is 2× base pay
+
+    const totalPay =
+      regularPay +
+      overtimeBase +
+      overtimePremium +
+      doubleBase +
+      doublePremium +
+      flatBonus;
+
+    const baseIfNoPremiums = rate * totalHours;
+    const extraFromOvertime = totalPay - baseIfNoPremiums;
+    const effectiveHourly = totalPay / totalHours;
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">Total pay: ${currencyFormatter.format(totalPay)}</h2>
+        <div class="stat-grid">
+          <div class="stat"><span class="label">Regular pay</span><span class="value">${currencyFormatter.format(regularPay)}</span></div>
+          <div class="stat"><span class="label">Overtime pay</span><span class="value">${currencyFormatter.format(overtimeBase + overtimePremium)}</span></div>
+          <div class="stat"><span class="label">Double-time pay</span><span class="value">${currencyFormatter.format(doubleBase + doublePremium)}</span></div>
+          <div class="stat"><span class="label">Bonuses & stipends</span><span class="value">${currencyFormatter.format(flatBonus)}</span></div>
+          <div class="stat"><span class="label">Total hours</span><span class="value">${numberFormatter.format(totalHours)} hrs</span></div>
+          <div class="stat"><span class="label">Effective hourly rate</span><span class="value">${currencyFormatter.format(effectiveHourly)}</span></div>
+        </div>
+        <div class="table-wrap" style="margin-top:18px;">
+          <table>
+            <thead>
+              <tr>
+                <th>Category</th>
+                <th>Hours</th>
+                <th>Pay</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td>Regular time</td><td>${numberFormatter.format(regularHours)}</td><td>${currencyFormatter.format(regularPay)}</td></tr>
+              <tr><td>Overtime (${numberFormatter.format(otMultiplier)}×)</td><td>${numberFormatter.format(otHours)}</td><td>${currencyFormatter.format(overtimeBase + overtimePremium)}</td></tr>
+              <tr><td>Double time (2×)</td><td>${numberFormatter.format(dblHours)}</td><td>${currencyFormatter.format(doubleBase + doublePremium)}</td></tr>
+              <tr><td>Premium earned</td><td>—</td><td>${currencyFormatter.format(extraFromOvertime)}</td></tr>
+              <tr><td>Bonus</td><td>—</td><td>${currencyFormatter.format(flatBonus)}</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="helper" style="margin-top:12px;">Base pay for all hours at the standard rate would be ${currencyFormatter.format(baseIfNoPremiums)}; overtime rules add ${currencyFormatter.format(extraFromOvertime)} in premiums.</p>
+      </section>
+    `;
+  }
+
+  form.addEventListener("submit", handleSubmit);
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+})();

--- a/public/js/paycheck-tax-calculator.js
+++ b/public/js/paycheck-tax-calculator.js
@@ -1,0 +1,227 @@
+(function () {
+  const form = document.getElementById("paycheck-form");
+  const resultEl = document.getElementById("paycheck-result");
+
+  if (!form || !resultEl) return;
+
+  const currencyFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+
+  const percentFormatter = new Intl.NumberFormat("en-US", {
+    style: "percent",
+    maximumFractionDigits: 2,
+  });
+
+  const numberFormatter = new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 2,
+  });
+
+  const payPeriods = {
+    annual: 1,
+    monthly: 12,
+    "semi-monthly": 24,
+    biweekly: 26,
+    weekly: 52,
+  };
+
+  const payLabels = {
+    annual: "year",
+    monthly: "month",
+    "semi-monthly": "paycheck",
+    biweekly: "paycheck",
+    weekly: "paycheck",
+  };
+
+  const stateRates = {
+    AL: 0.05,
+    AK: 0,
+    AZ: 0.025,
+    AR: 0.049,
+    CA: 0.06,
+    CO: 0.044,
+    CT: 0.05,
+    DE: 0.055,
+    DC: 0.06,
+    FL: 0,
+    GA: 0.05,
+    HI: 0.075,
+    ID: 0.058,
+    IL: 0.0495,
+    IN: 0.0323,
+    IA: 0.057,
+    KS: 0.057,
+    KY: 0.045,
+    LA: 0.0425,
+    ME: 0.058,
+    MD: 0.0575,
+    MA: 0.05,
+    MI: 0.0405,
+    MN: 0.068,
+    MS: 0.047,
+    MO: 0.0495,
+    MT: 0.059,
+    NE: 0.058,
+    NV: 0,
+    NH: 0,
+    NJ: 0.0637,
+    NM: 0.049,
+    NY: 0.065,
+    NC: 0.0475,
+    ND: 0.025,
+    OH: 0.035,
+    OK: 0.0475,
+    OR: 0.0775,
+    PA: 0.0307,
+    RI: 0.0599,
+    SC: 0.05,
+    SD: 0,
+    TN: 0,
+    TX: 0,
+    UT: 0.0465,
+    VT: 0.066,
+    VA: 0.0575,
+    WA: 0,
+    WV: 0.051,
+    WI: 0.05,
+    WY: 0,
+  };
+
+  const STANDARD_DEDUCTION = {
+    single: 14600,
+    married: 29200,
+  };
+
+  const FEDERAL_BRACKETS = {
+    single: [
+      { cap: 11600, rate: 0.1 },
+      { cap: 47150, rate: 0.12 },
+      { cap: 100525, rate: 0.22 },
+      { cap: 191950, rate: 0.24 },
+      { cap: 243725, rate: 0.32 },
+      { cap: 609350, rate: 0.35 },
+      { cap: Infinity, rate: 0.37 },
+    ],
+    married: [
+      { cap: 23200, rate: 0.1 },
+      { cap: 94300, rate: 0.12 },
+      { cap: 201050, rate: 0.22 },
+      { cap: 383900, rate: 0.24 },
+      { cap: 487450, rate: 0.32 },
+      { cap: 731200, rate: 0.35 },
+      { cap: Infinity, rate: 0.37 },
+    ],
+  };
+
+  function computeFederalTax(income, status) {
+    const brackets = FEDERAL_BRACKETS[status] || FEDERAL_BRACKETS.single;
+    const deduction = STANDARD_DEDUCTION[status] ?? STANDARD_DEDUCTION.single;
+    const taxable = Math.max(0, income - deduction);
+    let tax = 0;
+    let lower = 0;
+
+    for (const bracket of brackets) {
+      if (taxable <= lower) break;
+      const upper = Math.min(bracket.cap, taxable);
+      const amount = upper - lower;
+      if (amount > 0) {
+        tax += amount * bracket.rate;
+      }
+      lower = bracket.cap;
+    }
+
+    return tax;
+  }
+
+  function computeFica(wages, status) {
+    const wageBase = 168600;
+    const socialSecurity = Math.min(Math.max(wages, 0), wageBase) * 0.062;
+    const medicareBase = Math.max(wages, 0);
+    const medicare = medicareBase * 0.0145;
+    const additionalThreshold = status === "married" ? 250000 : 200000;
+    const additionalMedicare = Math.max(0, medicareBase - additionalThreshold) * 0.009;
+    return {
+      socialSecurity,
+      medicare: medicare + additionalMedicare,
+    };
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+
+    const income = parseFloat(form.income.value || "0");
+    const frequency = form.frequency.value;
+    const status = form.status.value === "married" ? "married" : "single";
+    const state = form.state.value;
+    const pretax = parseFloat(form.pretax.value || "0");
+    const posttax = parseFloat(form.posttax.value || "0");
+
+    if (!Number.isFinite(income) || income <= 0 || !payPeriods[frequency]) {
+      resultEl.innerHTML = `<section class="card"><p>Please enter a gross income above zero.</p></section>`;
+      return;
+    }
+
+    const periods = payPeriods[frequency];
+    const grossPerPeriod = income / periods;
+    const pretaxPerPeriod = Number.isFinite(pretax) && pretax > 0 ? pretax : 0;
+    const postTaxPerPeriod = Number.isFinite(posttax) && posttax > 0 ? posttax : 0;
+    const totalPretax = pretaxPerPeriod * periods;
+    const taxableAnnual = Math.max(0, income - totalPretax);
+
+    const federalTax = computeFederalTax(taxableAnnual, status);
+    const stateRate = stateRates[state] ?? 0;
+    const stateTax = taxableAnnual * stateRate;
+    const fica = computeFica(taxableAnnual, status);
+    const payrollTax = fica.socialSecurity + fica.medicare;
+    const postTaxAnnual = postTaxPerPeriod * periods;
+    const totalTax = federalTax + stateTax + payrollTax;
+    const netAnnual = Math.max(0, income - totalPretax - totalTax - postTaxAnnual);
+    const netPerPeriod = netAnnual / periods;
+
+    const effectiveRate = income > 0 ? totalTax / income : 0;
+    const frequencyLabel = payLabels[frequency] || "pay period";
+    const stateLabel = form.state.options[form.state.selectedIndex]?.text || state;
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">Estimated take-home: ${currencyFormatter.format(netPerPeriod)} per ${frequencyLabel}</h2>
+        <div class="stat-grid">
+          <div class="stat"><span class="label">Gross per ${frequencyLabel}</span><span class="value">${currencyFormatter.format(grossPerPeriod)}</span></div>
+          <div class="stat"><span class="label">Pre-tax deductions</span><span class="value">${currencyFormatter.format(pretaxPerPeriod)}</span></div>
+          <div class="stat"><span class="label">Taxes per ${frequencyLabel}</span><span class="value">${currencyFormatter.format(totalTax / periods)}</span></div>
+          <div class="stat"><span class="label">Net pay per ${frequencyLabel}</span><span class="value">${currencyFormatter.format(netPerPeriod)}</span></div>
+          <div class="stat"><span class="label">Annual take-home</span><span class="value">${currencyFormatter.format(netAnnual)}</span></div>
+          <div class="stat"><span class="label">Effective tax rate</span><span class="value">${percentFormatter.format(effectiveRate)}</span></div>
+        </div>
+        <div class="table-wrap" style="margin-top:18px;">
+          <table>
+            <thead>
+              <tr>
+                <th>Category</th>
+                <th>Annual</th>
+                <th>Per ${frequencyLabel}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td>Federal income tax</td><td>${currencyFormatter.format(federalTax)}</td><td>${currencyFormatter.format(federalTax / periods)}</td></tr>
+              <tr><td>${stateLabel} income tax</td><td>${currencyFormatter.format(stateTax)}</td><td>${currencyFormatter.format(stateTax / periods)}</td></tr>
+              <tr><td>Social Security</td><td>${currencyFormatter.format(fica.socialSecurity)}</td><td>${currencyFormatter.format(fica.socialSecurity / periods)}</td></tr>
+              <tr><td>Medicare</td><td>${currencyFormatter.format(fica.medicare)}</td><td>${currencyFormatter.format(fica.medicare / periods)}</td></tr>
+              <tr><td>Post-tax deductions</td><td>${currencyFormatter.format(postTaxAnnual)}</td><td>${currencyFormatter.format(postTaxPerPeriod)}</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="helper" style="margin-top:12px;">Standard deduction applied: ${currencyFormatter.format(STANDARD_DEDUCTION[status])}. ${stateRate === 0 ? `${stateLabel} has no state income tax in this estimate.` : `State rate assumed: ${numberFormatter.format(stateRate * 100)}%.`}</p>
+      </section>
+    `;
+  }
+
+  form.addEventListener("submit", handleSubmit);
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+})();

--- a/public/js/savings-vs-investing-comparison.js
+++ b/public/js/savings-vs-investing-comparison.js
@@ -1,0 +1,134 @@
+(function () {
+  const form = document.getElementById("compare-form");
+  const resultEl = document.getElementById("compare-result");
+
+  if (!form || !resultEl) return;
+
+  const currencyFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+
+  const numberFormatter = new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 2,
+  });
+
+  function runProjection(start, monthly, months, annualRate) {
+    const monthlyRate = annualRate / 100 / 12;
+    let balance = start;
+    let totalGrowth = 0;
+    let totalContributions = start;
+    let contributionsThisYear = 0;
+    let growthThisYear = 0;
+    const schedule = [];
+
+    for (let month = 1; month <= months; month += 1) {
+      const interest = balance * monthlyRate;
+      balance += interest;
+      totalGrowth += interest;
+      growthThisYear += interest;
+
+      if (monthly > 0) {
+        balance += monthly;
+        totalContributions += monthly;
+        contributionsThisYear += monthly;
+      }
+
+      if (month % 12 === 0 || month === months) {
+        schedule.push({
+          year: Math.ceil(month / 12),
+          partial: month % 12 !== 0,
+          contributions: contributionsThisYear,
+          growth: growthThisYear,
+          balance,
+        });
+        contributionsThisYear = 0;
+        growthThisYear = 0;
+      }
+    }
+
+    return { balance, totalGrowth, totalContributions, schedule };
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+
+    const start = parseFloat(form.start.value || "0");
+    const monthly = parseFloat(form.monthly.value || "0");
+    const years = parseFloat(form.years.value || "0");
+    const bankRate = parseFloat(form.bankRate.value || "0");
+    const marketRate = parseFloat(form.marketRate.value || "0");
+    const fees = parseFloat(form.fees.value || "0");
+
+    if (!Number.isFinite(start) || start < 0) {
+      resultEl.innerHTML = `<section class="card"><p>Starting balance can't be negative.</p></section>`;
+      return;
+    }
+
+    if (!Number.isFinite(years) || years <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Choose a time horizon greater than zero.</p></section>`;
+      return;
+    }
+
+    const months = Math.round(years * 12);
+    if (months <= 0) {
+      resultEl.innerHTML = `<section class="card"><p>Your timeframe is too short—try at least one month.</p></section>`;
+      return;
+    }
+
+    const monthlyContribution = Number.isFinite(monthly) && monthly > 0 ? monthly : 0;
+    const safeBankRate = Number.isFinite(bankRate) ? bankRate : 0;
+    const safeMarketRate = Number.isFinite(marketRate) ? marketRate : 0;
+    const feeRate = Number.isFinite(fees) && fees > 0 ? fees : 0;
+    const netMarketRate = safeMarketRate - feeRate;
+
+    const savingsProjection = runProjection(start, monthlyContribution, months, safeBankRate);
+    const investingProjection = runProjection(start, monthlyContribution, months, netMarketRate);
+
+    const difference = investingProjection.balance - savingsProjection.balance;
+    const totalContributions = savingsProjection.totalContributions; // same inputs for both
+
+    const tableRows = savingsProjection.schedule.map((row, index) => {
+      const investingRow = investingProjection.schedule[index];
+      const yearLabel = row.partial ? `Year ${row.year}*` : `Year ${row.year}`;
+      const investBalance = investingRow ? investingRow.balance : investingProjection.balance;
+      return `<tr><td>${yearLabel}</td><td>${currencyFormatter.format(row.balance)}</td><td>${currencyFormatter.format(investBalance)}</td><td>${currencyFormatter.format(investBalance - row.balance)}</td></tr>`;
+    });
+
+    resultEl.innerHTML = `
+      <section class="card">
+        <h2 style="margin-top:0;">Projected balances after ${numberFormatter.format(years)} years</h2>
+        <div class="stat-grid">
+          <div class="stat"><span class="label">Total contributed</span><span class="value">${currencyFormatter.format(totalContributions)}</span></div>
+          <div class="stat"><span class="label">Savings account balance</span><span class="value">${currencyFormatter.format(savingsProjection.balance)}</span></div>
+          <div class="stat"><span class="label">Savings growth earned</span><span class="value">${currencyFormatter.format(savingsProjection.totalGrowth)}</span></div>
+          <div class="stat"><span class="label">Investing balance (net of fees)</span><span class="value">${currencyFormatter.format(investingProjection.balance)}</span></div>
+          <div class="stat"><span class="label">Investing growth earned</span><span class="value">${currencyFormatter.format(investingProjection.totalGrowth)}</span></div>
+          <div class="stat"><span class="label">Difference</span><span class="value">${currencyFormatter.format(difference)}</span></div>
+        </div>
+        <div class="table-wrap" style="margin-top:18px;">
+          <table>
+            <thead>
+              <tr>
+                <th>Year</th>
+                <th>Savings balance</th>
+                <th>Investing balance</th>
+                <th>Difference</th>
+              </tr>
+            </thead>
+            <tbody>${tableRows.join("")}</tbody>
+          </table>
+        </div>
+        <p class="helper" style="margin-top:12px;">Investment return uses ${numberFormatter.format(safeMarketRate)}% minus ${numberFormatter.format(feeRate)}% in annual fees. Rows with an asterisk represent a partial year at the end of the timeline.</p>
+      </section>
+    `;
+  }
+
+  form.addEventListener("submit", handleSubmit);
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      resultEl.innerHTML = "";
+    }, 0);
+  });
+})();

--- a/src/lib/calculatorData.ts
+++ b/src/lib/calculatorData.ts
@@ -56,11 +56,46 @@ export const calculatorCategories: CalculatorCategory[] = [
     label: "Money & Planning",
     calculators: [
       {
+        href: "/calculators/paycheck-tax-calculator",
+        name: "Paycheck Tax Calculator",
+        navLabel: "Paycheck",
+        description:
+          "Estimate take-home pay by state with federal, payroll, and state taxes.",
+      },
+      {
+        href: "/calculators/overtime-pay-calculator",
+        name: "Overtime Pay Calculator",
+        navLabel: "Overtime",
+        description:
+          "See total pay when overtime and double-time hours stack onto your shift.",
+      },
+      {
+        href: "/calculators/freelancer-hourly-rate-calculator",
+        name: "Freelancer Hourly Rate",
+        navLabel: "Freelance",
+        description:
+          "Back into a sustainable freelance rate using income goals and billable hours.",
+      },
+      {
+        href: "/calculators/salary-to-hourly",
+        name: "Salary ↔ Hourly",
+        navLabel: "Salary",
+        description:
+          "Convert yearly pay to hourly wages (and vice versa) with your schedule.",
+      },
+      {
         href: "/calculators/loan-calculator",
         name: "Loan Calculator",
         navLabel: "Loan",
         description:
           "Estimate payments and see principal versus interest by year.",
+      },
+      {
+        href: "/calculators/car-loan-affordability-calculator",
+        name: "Car Loan Affordability",
+        navLabel: "Car Budget",
+        description:
+          "Find the maximum vehicle price your income can comfortably support.",
       },
       {
         href: "/calculators/mortgage-calculator",
@@ -70,11 +105,39 @@ export const calculatorCategories: CalculatorCategory[] = [
           "Check affordability, monthly costs, and an amortization schedule.",
       },
       {
+        href: "/calculators/debt-payoff-calculator",
+        name: "Debt Payoff Calculator",
+        navLabel: "Debt",
+        description:
+          "Compare snowball and avalanche payoff timelines across all your debts.",
+      },
+      {
+        href: "/calculators/credit-card-interest-calculator",
+        name: "Credit Card Interest",
+        navLabel: "Card Interest",
+        description:
+          "Project interest charges while carrying a balance and test extra payments.",
+      },
+      {
         href: "/calculators/compound-interest-calculator",
         name: "Compound Interest",
         navLabel: "Invest",
         description:
           "Model investment growth with recurring deposits and raises.",
+      },
+      {
+        href: "/calculators/savings-goal-calculator",
+        name: "Savings Goal",
+        navLabel: "Savings",
+        description:
+          "See the monthly deposit needed to reach a target with growth.",
+      },
+      {
+        href: "/calculators/savings-vs-investing-comparison",
+        name: "Savings vs Investing",
+        navLabel: "Save vs Invest",
+        description:
+          "Compare bank interest against market returns using the same contributions.",
       },
       {
         href: "/calculators/currency-converter",
@@ -91,25 +154,11 @@ export const calculatorCategories: CalculatorCategory[] = [
           "Compare the buying power of money across different years.",
       },
       {
-        href: "/calculators/salary-to-hourly",
-        name: "Salary ↔ Hourly",
-        navLabel: "Salary",
-        description:
-          "Convert yearly pay to hourly wages (and vice versa) with your schedule.",
-      },
-      {
         href: "/calculators/tip-calculator",
         name: "Tip Splitter",
         navLabel: "Tip",
         description:
           "Quickly find tip amounts and per-person totals for the table.",
-      },
-      {
-        href: "/calculators/savings-goal-calculator",
-        name: "Savings Goal",
-        navLabel: "Savings",
-        description:
-          "See the monthly deposit needed to reach a target with growth.",
       },
     ],
   },

--- a/src/pages/calculators/car-loan-affordability-calculator.astro
+++ b/src/pages/calculators/car-loan-affordability-calculator.astro
@@ -1,0 +1,76 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Car Loan Affordability Calculator";
+const description = "Estimate a comfortable vehicle price using income, existing debt, and loan terms.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/car-loan-affordability-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Plug in your household income, other monthly debt, and loan assumptions to see the largest car payment that keeps your
+      debt-to-income ratio on target. We'll convert that into an estimated car price based on your down payment.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="car-form">
+      <div class="form-grid">
+        <div>
+          <label for="car-income">Gross annual income</label>
+          <input id="car-income" name="income" type="number" min="0" step="500" placeholder="90000" required />
+        </div>
+        <div>
+          <label for="car-debts">Current monthly debt payments (student loans, credit cards, etc.)</label>
+          <input id="car-debts" name="debts" type="number" min="0" step="10" placeholder="600" />
+        </div>
+        <div>
+          <label for="car-term">Loan term</label>
+          <select id="car-term" name="term" required>
+            <option value="36">36 months</option>
+            <option value="48">48 months</option>
+            <option value="60" selected>60 months</option>
+            <option value="72">72 months</option>
+            <option value="84">84 months</option>
+          </select>
+        </div>
+        <div>
+          <label for="car-rate">Loan APR (%)</label>
+          <input id="car-rate" name="rate" type="number" min="0" step="0.01" placeholder="6.5" />
+        </div>
+        <div>
+          <label for="car-down">Cash down payment</label>
+          <input id="car-down" name="down" type="number" min="0" step="100" placeholder="8000" />
+        </div>
+        <div>
+          <label for="car-trade">Trade-in value (after loan payoff)</label>
+          <input id="car-trade" name="trade" type="number" min="0" step="100" placeholder="0" />
+        </div>
+        <div>
+          <label for="car-dti">Target share of monthly income for the car (%)</label>
+          <input id="car-dti" name="share" type="number" min="1" max="50" step="1" value="15" />
+        </div>
+        <div>
+          <label for="car-tax">Sales tax rate (%)</label>
+          <input id="car-tax" name="tax" type="number" min="0" step="0.1" placeholder="6.5" />
+        </div>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Estimate car budget</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">
+        Financial planners often suggest keeping the car payment below 15% of gross income. Adjust the target percentage or add
+        more to the down payment to see how it changes the affordable sticker price.
+      </p>
+    </form>
+  </section>
+
+  <section id="car-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="car-inline-1" />
+  <script defer src="/js/car-loan-affordability-calculator.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/credit-card-interest-calculator.astro
+++ b/src/pages/calculators/credit-card-interest-calculator.astro
@@ -1,0 +1,62 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Credit Card Interest Calculator";
+const description = "Project the cost of revolving a credit card balance and see how extra payments shorten payoff time.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/credit-card-interest-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Input a balance, APR, and the amount you pay each month to estimate interest charges. Add optional new spending or an
+      extra payment to compare how quickly the balance disappears.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="credit-form">
+      <div class="form-grid">
+        <div>
+          <label for="credit-balance">Current balance</label>
+          <input id="credit-balance" name="balance" type="number" min="0" step="10" placeholder="4500" required />
+        </div>
+        <div>
+          <label for="credit-rate">APR (%)</label>
+          <input id="credit-rate" name="rate" type="number" min="0" step="0.01" placeholder="19.99" required />
+        </div>
+        <div>
+          <label for="credit-payment">Monthly payment</label>
+          <input id="credit-payment" name="payment" type="number" min="0" step="1" placeholder="180" required />
+        </div>
+        <div>
+          <label for="credit-extra">Additional monthly payment (optional)</label>
+          <input id="credit-extra" name="extra" type="number" min="0" step="1" placeholder="75" />
+        </div>
+        <div>
+          <label for="credit-charges">New charges per month (optional)</label>
+          <input id="credit-charges" name="charges" type="number" min="0" step="1" placeholder="0" />
+        </div>
+        <div>
+          <label for="credit-min">Minimum payment floor</label>
+          <input id="credit-min" name="minimum" type="number" min="0" step="1" value="25" />
+        </div>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Estimate interest</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">
+        Results assume interest accrues on the remaining balance each month after new charges are added and before payments are
+        applied. If your payment is less than the monthly interest, the balance will continue to grow.
+      </p>
+    </form>
+  </section>
+
+  <section id="credit-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="credit-inline-1" />
+  <script defer src="/js/credit-card-interest-calculator.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/debt-payoff-calculator.astro
+++ b/src/pages/calculators/debt-payoff-calculator.astro
@@ -1,0 +1,51 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Debt Payoff Calculator";
+const description = "Compare the snowball vs. avalanche strategy with payoff timelines and interest totals.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/debt-payoff-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      List each debt's balance, APR, and minimum payment to see how long it takes to become debt-free. Compare the debt snowball
+      (smallest balance first) and avalanche (highest interest rate first) side by side.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="debt-form">
+      <p class="helper" style="margin-top:0;">
+        Include credit cards, personal loans, and student loans. We'll apply your extra payment to whichever debt is targeted by
+        the chosen strategy after covering all minimums.
+      </p>
+
+      <div id="debt-rows" style="display:flex; flex-direction:column; gap:16px; margin-top:12px;"></div>
+
+      <button id="add-debt" class="btn" type="button" style="margin-top:6px; width:fit-content;">Add another debt</button>
+
+      <div class="form-grid" style="margin-top:18px;">
+        <div>
+          <label for="debt-extra">Extra monthly payment toward debt</label>
+          <input id="debt-extra" name="extra" type="number" min="0" step="10" placeholder="250" />
+        </div>
+        <div>
+          <label for="debt-start">Starting month (optional)</label>
+          <input id="debt-start" name="start" type="month" />
+        </div>
+      </div>
+
+      <div style="margin-top:16px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Compare snowball & avalanche</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+    </form>
+  </section>
+
+  <section id="debt-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="debt-inline-1" />
+  <script defer src="/js/debt-payoff-calculator.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/freelancer-hourly-rate-calculator.astro
+++ b/src/pages/calculators/freelancer-hourly-rate-calculator.astro
@@ -1,0 +1,76 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Freelancer Hourly Rate Calculator";
+const description = "Back into a sustainable freelance rate using income goals, billable hours, and overhead.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/freelancer-hourly-rate-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Estimate a target hourly and project rate by combining the income you want, yearly business expenses, and how many hours
+      you can bill. Add a project scope to translate the rate into a suggested quote.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="freelance-form">
+      <div class="form-grid">
+        <div>
+          <label for="freelance-income">Desired annual take-home pay</label>
+          <input id="freelance-income" name="income" type="number" min="0" step="500" placeholder="85000" required />
+        </div>
+        <div>
+          <label for="freelance-expenses">Estimated annual business expenses</label>
+          <input id="freelance-expenses" name="expenses" type="number" min="0" step="100" placeholder="12000" />
+        </div>
+        <div>
+          <label for="freelance-hours">Billable hours per week</label>
+          <input id="freelance-hours" name="hours" type="number" min="1" step="0.5" placeholder="25" required />
+        </div>
+        <div>
+          <label for="freelance-weeks">Unpaid weeks off each year</label>
+          <input id="freelance-weeks" name="weeksOff" type="number" min="0" step="0.5" placeholder="4" />
+        </div>
+        <div>
+          <label for="freelance-margin">Profit cushion (%)</label>
+          <input id="freelance-margin" name="margin" type="number" min="0" max="200" step="1" value="20" />
+        </div>
+        <div>
+          <label for="freelance-tax">Self-employment tax & benefits reserve (%)</label>
+          <input id="freelance-tax" name="reserve" type="number" min="0" max="100" step="1" value="25" />
+        </div>
+      </div>
+
+      <fieldset>
+        <legend>Optional project quote</legend>
+        <div class="form-grid">
+          <div>
+            <label for="freelance-project-hours">Estimated project hours</label>
+            <input id="freelance-project-hours" name="projectHours" type="number" min="0" step="1" placeholder="60" />
+          </div>
+          <div>
+            <label for="freelance-project-expenses">Project expenses (subcontractors, travel, etc.)</label>
+            <input id="freelance-project-expenses" name="projectExpenses" type="number" min="0" step="10" placeholder="400" />
+          </div>
+        </div>
+      </fieldset>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Calculate rate</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">
+        The reserve percentage sets aside money for taxes, retirement, and slow periods. Adjust the profit cushion to build in
+        extra margin for admin time and surprises.
+      </p>
+    </form>
+  </section>
+
+  <section id="freelance-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="freelance-inline-1" />
+  <script defer src="/js/freelancer-hourly-rate-calculator.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/overtime-pay-calculator.astro
+++ b/src/pages/calculators/overtime-pay-calculator.astro
@@ -1,0 +1,62 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Overtime Pay Calculator";
+const description = "Estimate total pay with overtime premiums, double time, and flat shift bonuses.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/overtime-pay-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Enter your hourly rate and the hours worked at each pay level to see how much extra overtime adds to your paycheck. The
+      calculator handles common 1.5× overtime and optional 2× double time.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="overtime-form">
+      <div class="form-grid">
+        <div>
+          <label for="ot-rate">Base hourly rate</label>
+          <input id="ot-rate" name="rate" type="number" min="0" step="0.01" placeholder="22.5" required />
+        </div>
+        <div>
+          <label for="ot-regular-hours">Regular hours (paid at base rate)</label>
+          <input id="ot-regular-hours" name="regularHours" type="number" min="0" step="0.1" placeholder="40" required />
+        </div>
+        <div>
+          <label for="ot-overtime-hours">Overtime hours</label>
+          <input id="ot-overtime-hours" name="overtimeHours" type="number" min="0" step="0.1" placeholder="6" />
+        </div>
+        <div>
+          <label for="ot-multiplier">Overtime multiplier</label>
+          <input id="ot-multiplier" name="multiplier" type="number" min="1" step="0.1" value="1.5" />
+        </div>
+        <div>
+          <label for="ot-double-hours">Double-time hours (2×)</label>
+          <input id="ot-double-hours" name="doubleHours" type="number" min="0" step="0.1" placeholder="0" />
+        </div>
+        <div>
+          <label for="ot-bonus">Flat bonus or stipend</label>
+          <input id="ot-bonus" name="bonus" type="number" min="0" step="1" placeholder="0" />
+        </div>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Calculate pay</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">
+        Overtime laws vary by state and union contract. This tool simply multiplies the hours you provide—double-check which
+        hours qualify for overtime on your timesheet.
+      </p>
+    </form>
+  </section>
+
+  <section id="overtime-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="overtime-inline-1" />
+  <script defer src="/js/overtime-pay-calculator.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/paycheck-tax-calculator.astro
+++ b/src/pages/calculators/paycheck-tax-calculator.astro
@@ -1,0 +1,129 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Paycheck Tax Calculator";
+const description = "Estimate take-home pay by state with federal, payroll, and local tax assumptions.";
+
+const states = [
+  { code: "AL", name: "Alabama" },
+  { code: "AK", name: "Alaska" },
+  { code: "AZ", name: "Arizona" },
+  { code: "AR", name: "Arkansas" },
+  { code: "CA", name: "California" },
+  { code: "CO", name: "Colorado" },
+  { code: "CT", name: "Connecticut" },
+  { code: "DE", name: "Delaware" },
+  { code: "DC", name: "District of Columbia" },
+  { code: "FL", name: "Florida" },
+  { code: "GA", name: "Georgia" },
+  { code: "HI", name: "Hawaii" },
+  { code: "ID", name: "Idaho" },
+  { code: "IL", name: "Illinois" },
+  { code: "IN", name: "Indiana" },
+  { code: "IA", name: "Iowa" },
+  { code: "KS", name: "Kansas" },
+  { code: "KY", name: "Kentucky" },
+  { code: "LA", name: "Louisiana" },
+  { code: "ME", name: "Maine" },
+  { code: "MD", name: "Maryland" },
+  { code: "MA", name: "Massachusetts" },
+  { code: "MI", name: "Michigan" },
+  { code: "MN", name: "Minnesota" },
+  { code: "MS", name: "Mississippi" },
+  { code: "MO", name: "Missouri" },
+  { code: "MT", name: "Montana" },
+  { code: "NE", name: "Nebraska" },
+  { code: "NV", name: "Nevada" },
+  { code: "NH", name: "New Hampshire" },
+  { code: "NJ", name: "New Jersey" },
+  { code: "NM", name: "New Mexico" },
+  { code: "NY", name: "New York" },
+  { code: "NC", name: "North Carolina" },
+  { code: "ND", name: "North Dakota" },
+  { code: "OH", name: "Ohio" },
+  { code: "OK", name: "Oklahoma" },
+  { code: "OR", name: "Oregon" },
+  { code: "PA", name: "Pennsylvania" },
+  { code: "RI", name: "Rhode Island" },
+  { code: "SC", name: "South Carolina" },
+  { code: "SD", name: "South Dakota" },
+  { code: "TN", name: "Tennessee" },
+  { code: "TX", name: "Texas" },
+  { code: "UT", name: "Utah" },
+  { code: "VT", name: "Vermont" },
+  { code: "VA", name: "Virginia" },
+  { code: "WA", name: "Washington" },
+  { code: "WV", name: "West Virginia" },
+  { code: "WI", name: "Wisconsin" },
+  { code: "WY", name: "Wyoming" },
+];
+---
+
+<BaseLayout {title} {description} pathname="/calculators/paycheck-tax-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      See an approximate paycheck breakdown with federal brackets, FICA payroll taxes, and a flat state income tax rate.
+      Enter per-paycheck deductions to tailor the net pay estimate to your situation.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="paycheck-form">
+      <div class="form-grid">
+        <div>
+          <label for="paycheck-income">Annual gross pay</label>
+          <input id="paycheck-income" name="income" type="number" min="0" step="100" placeholder="75000" required />
+        </div>
+        <div>
+          <label for="paycheck-frequency">Pay frequency</label>
+          <select id="paycheck-frequency" name="frequency" required>
+            <option value="annual">Annually (1×)</option>
+            <option value="monthly">Monthly (12×)</option>
+            <option value="semi-monthly">Semi-monthly (24×)</option>
+            <option value="biweekly">Biweekly (26×)</option>
+            <option value="weekly">Weekly (52×)</option>
+          </select>
+        </div>
+        <div>
+          <label for="paycheck-filing">Filing status</label>
+          <select id="paycheck-filing" name="status" required>
+            <option value="single">Single</option>
+            <option value="married">Married filing jointly</option>
+          </select>
+        </div>
+        <div>
+          <label for="paycheck-state">State</label>
+          <select id="paycheck-state" name="state" required>
+            {states.map((state) => (
+              <option value={state.code}>{state.name}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label for="paycheck-pretax">Pre-tax deductions per paycheck (401k, HSA, etc.)</label>
+          <input id="paycheck-pretax" name="pretax" type="number" min="0" step="10" placeholder="250" />
+        </div>
+        <div>
+          <label for="paycheck-posttax">Post-tax deductions per paycheck</label>
+          <input id="paycheck-posttax" name="posttax" type="number" min="0" step="10" placeholder="75" />
+        </div>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Estimate take-home</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">
+        Federal tax brackets and standard deductions use 2024 values. State tax uses an approximate flat rate by state for a
+        quick comparison and does not include local withholding.
+      </p>
+    </form>
+  </section>
+
+  <section id="paycheck-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="paycheck-inline-1" />
+  <script defer src="/js/paycheck-tax-calculator.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/savings-vs-investing-comparison.astro
+++ b/src/pages/calculators/savings-vs-investing-comparison.astro
@@ -1,0 +1,62 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Savings vs Investing Comparison";
+const description = "Compare projected growth of cash kept in a bank account versus invested in the market.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/savings-vs-investing-comparison">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Model side-by-side results for keeping money in a savings account versus investing it. Adjust the return assumptions,
+      monthly contributions, and time horizon to see how the gap changes.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="compare-form">
+      <div class="form-grid">
+        <div>
+          <label for="compare-start">Starting balance</label>
+          <input id="compare-start" name="start" type="number" min="0" step="100" placeholder="10000" required />
+        </div>
+        <div>
+          <label for="compare-monthly">Monthly contribution</label>
+          <input id="compare-monthly" name="monthly" type="number" min="0" step="10" placeholder="400" />
+        </div>
+        <div>
+          <label for="compare-years">Years to grow</label>
+          <input id="compare-years" name="years" type="number" min="1" step="1" placeholder="10" required />
+        </div>
+        <div>
+          <label for="compare-bank">Bank APY (%)</label>
+          <input id="compare-bank" name="bankRate" type="number" min="0" step="0.01" placeholder="3" />
+        </div>
+        <div>
+          <label for="compare-market">Expected investment return (%)</label>
+          <input id="compare-market" name="marketRate" type="number" step="0.1" placeholder="7" />
+        </div>
+        <div>
+          <label for="compare-fee">Investment fees (%)</label>
+          <input id="compare-fee" name="fees" type="number" min="0" step="0.01" placeholder="0.15" />
+        </div>
+      </div>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Compare growth</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+      <p class="helper" style="margin-top:10px;">
+        Returns are compounded monthly. Investment fees are treated as a reduction of the market return. Remember that actual
+        investing returns can be volatile and may not match a steady average.
+      </p>
+    </form>
+  </section>
+
+  <section id="compare-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="compare-inline-1" />
+  <script defer src="/js/savings-vs-investing-comparison.js"></script>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- add paycheck tax, overtime pay, and freelancer hourly rate calculators with interactive breakdowns
- add debt payoff, credit card interest, car affordability, and savings vs investing comparison tools
- update calculator navigation data so the new finance tools appear in the money & planning menu

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c969986f88832387ad0d8b4d8e292a