### PR TITLE
Add travel, writing, and planning calculators

### DIFF
--- a/public/js/event-budget-calculator.js
+++ b/public/js/event-budget-calculator.js
@@ -1,0 +1,123 @@
+(function () {
+  if (typeof window === "undefined") return;
+
+  const form = document.getElementById("event-budget-form");
+  const statusEl = document.getElementById("event-status");
+  const resultEl = document.getElementById("event-result");
+
+  if (!form || !statusEl || !resultEl) return;
+
+  function parseMoney(value) {
+    if (!value) return 0;
+    const numeric = Number(String(value).replace(/[^0-9.-]/g, ""));
+    return Number.isFinite(numeric) ? numeric : 0;
+  }
+
+  function formatCurrency(amount) {
+    return amount.toLocaleString(undefined, {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    });
+  }
+
+  function buildBreakdownRows(entries) {
+    return entries
+      .filter((entry) => entry.amount > 0)
+      .map(
+        (entry) =>
+          `<tr><td>${entry.label}</td><td style="text-align:right;">${formatCurrency(entry.amount)}</td></tr>`
+      )
+      .join("");
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+
+    const guests = Number(form.guests.value);
+    if (!Number.isFinite(guests) || guests <= 0) {
+      statusEl.textContent = "Enter the guest count to build a budget.";
+      resultEl.innerHTML = "";
+      return;
+    }
+
+    const hours = Number(form.hours.value) > 0 ? Number(form.hours.value) : null;
+    const name = form.name.value ? form.name.value.trim() : "Your event";
+
+    const venue = parseMoney(form.venue.value);
+    const decor = parseMoney(form.decor.value);
+    const entertainment = parseMoney(form.entertainment.value);
+    const staff = parseMoney(form.staff.value);
+    const foodPerGuest = parseMoney(form.food.value);
+    const drinkPerGuest = parseMoney(form.drink.value);
+    const extrasPerGuest = parseMoney(form.extras.value);
+    const servicePercent = Number(form.service.value) || 0;
+    const contingencyPercent = Number(form.contingency.value) || 0;
+
+    const perGuestTotal = foodPerGuest + drinkPerGuest + extrasPerGuest;
+    const variableTotal = perGuestTotal * guests;
+    const fixedTotal = venue + decor + entertainment + staff;
+    const subtotal = fixedTotal + variableTotal;
+    const serviceFee = (servicePercent / 100) * subtotal;
+    const preContingency = subtotal + serviceFee;
+    const contingency = (contingencyPercent / 100) * preContingency;
+    const grandTotal = preContingency + contingency;
+    const perGuestCost = grandTotal / guests;
+    const perHour = hours ? grandTotal / hours : null;
+
+    const breakdown = [
+      { label: "Venue & rentals", amount: venue },
+      { label: "Decor & design", amount: decor },
+      { label: "Entertainment", amount: entertainment },
+      { label: "Staffing & labor", amount: staff },
+      { label: "Food (variable)", amount: foodPerGuest * guests },
+      { label: "Beverage (variable)", amount: drinkPerGuest * guests },
+      { label: "Extras (variable)", amount: extrasPerGuest * guests },
+      { label: `Service charge (${servicePercent.toFixed(1)}%)`, amount: serviceFee },
+      { label: `Contingency (${contingencyPercent.toFixed(1)}%)`, amount: contingency },
+    ];
+
+    statusEl.textContent = `Estimated total budget: ${formatCurrency(grandTotal)} (${formatCurrency(
+      perGuestCost
+    )} per guest).`;
+
+    resultEl.innerHTML = `
+      <div class="card" style="margin-top:0;">
+        <h2 style="margin-top:0;">${name} budget summary</h2>
+        <ul class="result-list">
+          <li><strong>Guests:</strong> ${guests.toLocaleString()}</li>
+          <li><strong>Per-guest spend:</strong> ${formatCurrency(perGuestCost)}</li>
+          <li><strong>Subtotal before fees:</strong> ${formatCurrency(subtotal)}</li>
+          <li><strong>Service & contingency:</strong> ${formatCurrency(serviceFee + contingency)}</li>
+          <li><strong>Total event cost:</strong> ${formatCurrency(grandTotal)}</li>
+          ${
+            perHour
+              ? `<li><strong>Cost per hour (approx.):</strong> ${formatCurrency(perHour)}</li>`
+              : ""
+          }
+        </ul>
+        <h3>Line-item breakdown</h3>
+        <table class="table" style="width:100%;">
+          <tbody>
+            ${buildBreakdownRows(breakdown)}
+          </tbody>
+        </table>
+        <p class="helper">
+          Variable costs scale directly with guest count. Try adjusting service or contingency percentages to build in a safety
+          buffer for tips, overtime, or last-minute add-ons.
+        </p>
+      </div>
+    `;
+  }
+
+  function handleReset() {
+    statusEl.textContent = "Enter at least a guest count to see the budget.";
+    resultEl.innerHTML = "";
+  }
+
+  form.addEventListener("submit", handleSubmit);
+  form.addEventListener("reset", () => {
+    window.requestAnimationFrame(handleReset);
+  });
+})();

--- a/public/js/flight-time-calculator.js
+++ b/public/js/flight-time-calculator.js
@@ -1,0 +1,458 @@
+(function () {
+  if (typeof window === "undefined") return;
+
+  const airports = [
+    {
+      code: "ATL",
+      name: "Hartsfield–Jackson Atlanta International",
+      city: "Atlanta, USA",
+      timeZone: "America/New_York",
+      lat: 33.6407,
+      lon: -84.4277,
+    },
+    {
+      code: "JFK",
+      name: "John F. Kennedy International",
+      city: "New York City, USA",
+      timeZone: "America/New_York",
+      lat: 40.6413,
+      lon: -73.7781,
+    },
+    {
+      code: "LAX",
+      name: "Los Angeles International",
+      city: "Los Angeles, USA",
+      timeZone: "America/Los_Angeles",
+      lat: 33.9416,
+      lon: -118.4085,
+    },
+    {
+      code: "ORD",
+      name: "Chicago O'Hare International",
+      city: "Chicago, USA",
+      timeZone: "America/Chicago",
+      lat: 41.9742,
+      lon: -87.9073,
+    },
+    {
+      code: "DFW",
+      name: "Dallas/Fort Worth International",
+      city: "Dallas, USA",
+      timeZone: "America/Chicago",
+      lat: 32.8998,
+      lon: -97.0403,
+    },
+    {
+      code: "DEN",
+      name: "Denver International",
+      city: "Denver, USA",
+      timeZone: "America/Denver",
+      lat: 39.8561,
+      lon: -104.6737,
+    },
+    {
+      code: "SEA",
+      name: "Seattle–Tacoma International",
+      city: "Seattle, USA",
+      timeZone: "America/Los_Angeles",
+      lat: 47.4502,
+      lon: -122.3088,
+    },
+    {
+      code: "MIA",
+      name: "Miami International",
+      city: "Miami, USA",
+      timeZone: "America/New_York",
+      lat: 25.7959,
+      lon: -80.2871,
+    },
+    {
+      code: "YYZ",
+      name: "Toronto Pearson International",
+      city: "Toronto, Canada",
+      timeZone: "America/Toronto",
+      lat: 43.6777,
+      lon: -79.6248,
+    },
+    {
+      code: "LHR",
+      name: "London Heathrow",
+      city: "London, United Kingdom",
+      timeZone: "Europe/London",
+      lat: 51.47,
+      lon: -0.4543,
+    },
+    {
+      code: "CDG",
+      name: "Paris Charles de Gaulle",
+      city: "Paris, France",
+      timeZone: "Europe/Paris",
+      lat: 49.0097,
+      lon: 2.5479,
+    },
+    {
+      code: "FRA",
+      name: "Frankfurt Airport",
+      city: "Frankfurt, Germany",
+      timeZone: "Europe/Berlin",
+      lat: 50.0379,
+      lon: 8.5622,
+    },
+    {
+      code: "DXB",
+      name: "Dubai International",
+      city: "Dubai, UAE",
+      timeZone: "Asia/Dubai",
+      lat: 25.2532,
+      lon: 55.3657,
+    },
+    {
+      code: "HND",
+      name: "Tokyo Haneda",
+      city: "Tokyo, Japan",
+      timeZone: "Asia/Tokyo",
+      lat: 35.5494,
+      lon: 139.7798,
+    },
+    {
+      code: "SYD",
+      name: "Sydney Kingsford Smith",
+      city: "Sydney, Australia",
+      timeZone: "Australia/Sydney",
+      lat: -33.9399,
+      lon: 151.1753,
+    },
+    {
+      code: "SFO",
+      name: "San Francisco International",
+      city: "San Francisco, USA",
+      timeZone: "America/Los_Angeles",
+      lat: 37.6213,
+      lon: -122.379,
+    },
+    {
+      code: "GRU",
+      name: "São Paulo/Guarulhos",
+      city: "São Paulo, Brazil",
+      timeZone: "America/Sao_Paulo",
+      lat: -23.4356,
+      lon: -46.4731,
+    },
+    {
+      code: "EZE",
+      name: "Buenos Aires Ministro Pistarini",
+      city: "Buenos Aires, Argentina",
+      timeZone: "America/Argentina/Buenos_Aires",
+      lat: -34.8222,
+      lon: -58.5358,
+    },
+    {
+      code: "SIN",
+      name: "Singapore Changi",
+      city: "Singapore",
+      timeZone: "Asia/Singapore",
+      lat: 1.3644,
+      lon: 103.9915,
+    },
+    {
+      code: "JNB",
+      name: "O. R. Tambo International",
+      city: "Johannesburg, South Africa",
+      timeZone: "Africa/Johannesburg",
+      lat: -26.1367,
+      lon: 28.241,
+    },
+  ];
+
+  const airportMap = new Map(airports.map((airport) => [airport.code, airport]));
+
+  const form = document.getElementById("flight-form");
+  if (!form) return;
+
+  const fromSelect = document.getElementById("flight-from");
+  const toSelect = document.getElementById("flight-to");
+  const dateInput = document.getElementById("flight-date");
+  const timeInput = document.getElementById("flight-time");
+  const speedInput = document.getElementById("flight-speed");
+  const swapButton = document.getElementById("flight-swap");
+  const statusEl = document.getElementById("flight-status");
+  const resultEl = document.getElementById("flight-result");
+  const notesEl = document.getElementById("flight-airport-notes");
+
+  function populateAirports(select) {
+    if (!select) return;
+    airports
+      .slice()
+      .sort((a, b) => a.city.localeCompare(b.city))
+      .forEach((airport) => {
+        const option = document.createElement("option");
+        option.value = airport.code;
+        option.textContent = `${airport.city} (${airport.code})`;
+        option.dataset.tz = airport.timeZone;
+        select.appendChild(option);
+      });
+  }
+
+  function toRadians(value) {
+    return (value * Math.PI) / 180;
+  }
+
+  function haversineDistance(lat1, lon1, lat2, lon2) {
+    const R = 6371.0088; // kilometers
+    const dLat = toRadians(lat2 - lat1);
+    const dLon = toRadians(lon2 - lon1);
+    const a =
+      Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+      Math.cos(toRadians(lat1)) *
+        Math.cos(toRadians(lat2)) *
+        Math.sin(dLon / 2) *
+        Math.sin(dLon / 2);
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    return R * c;
+  }
+
+  function getOffset(date, timeZone) {
+    const dtf = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    });
+    const parts = dtf.formatToParts(date);
+    const map = {};
+    for (const { type, value } of parts) {
+      if (type !== "literal") map[type] = value;
+    }
+    const asUTC = Date.UTC(
+      Number(map.year),
+      Number(map.month) - 1,
+      Number(map.day),
+      Number(map.hour),
+      Number(map.minute),
+      Number(map.second)
+    );
+    return (asUTC - date.getTime()) / 60000; // minutes difference from UTC
+  }
+
+  function zonedDateToUtc(parts, timeZone) {
+    const date = new Date(
+      Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute)
+    );
+    const offset = getOffset(date, timeZone);
+    return new Date(date.getTime() - offset * 60000);
+  }
+
+  function formatLocal(date, timeZone) {
+    return new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(date);
+  }
+
+  function formatDuration(totalMinutes) {
+    const minutes = Math.round(totalMinutes);
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    const parts = [];
+    if (hours > 0) parts.push(`${hours} hour${hours === 1 ? "" : "s"}`);
+    parts.push(`${mins} minute${mins === 1 ? "" : "s"}`);
+    return parts.join(" ");
+  }
+
+  function formatOffsetLabel(offsetMinutes) {
+    const sign = offsetMinutes >= 0 ? "+" : "-";
+    const abs = Math.abs(offsetMinutes);
+    const hours = String(Math.floor(abs / 60)).padStart(2, "0");
+    const minutes = String(abs % 60).padStart(2, "0");
+    return `UTC${sign}${hours}:${minutes}`;
+  }
+
+  function parseDateInput(value) {
+    if (!value) return null;
+    const [year, month, day] = value.split("-").map(Number);
+    if (
+      Number.isNaN(year) ||
+      Number.isNaN(month) ||
+      Number.isNaN(day) ||
+      month < 1 ||
+      month > 12 ||
+      day < 1 ||
+      day > 31
+    ) {
+      return null;
+    }
+    return { year, month, day };
+  }
+
+  function parseTimeInput(value) {
+    if (!value) return null;
+    const [hour, minute] = value.split(":").map(Number);
+    if (
+      Number.isNaN(hour) ||
+      Number.isNaN(minute) ||
+      hour < 0 ||
+      hour > 23 ||
+      minute < 0 ||
+      minute > 59
+    ) {
+      return null;
+    }
+    return { hour, minute };
+  }
+
+  function updateNotes() {
+    if (!notesEl) return;
+    const from = airportMap.get(fromSelect.value || "");
+    const to = airportMap.get(toSelect.value || "");
+    const today = new Date();
+    const parts = [];
+    if (from) {
+      const offset = formatOffsetLabel(getOffset(today, from.timeZone));
+      parts.push(`${from.city} (${from.code}) • ${offset}`);
+    }
+    if (to) {
+      const offset = formatOffsetLabel(getOffset(today, to.timeZone));
+      parts.push(`${to.city} (${to.code}) • ${offset}`);
+    }
+    notesEl.textContent = parts.length
+      ? parts.join(" · ")
+      : "We'll highlight the local time zone offsets as you choose airports.";
+  }
+
+  function resetResult() {
+    if (resultEl) resultEl.innerHTML = "";
+    if (statusEl) statusEl.textContent = "Pick airports to begin.";
+  }
+
+  populateAirports(fromSelect);
+  populateAirports(toSelect);
+  updateNotes();
+
+  if (dateInput) {
+    const today = new Date();
+    const iso = today.toISOString().split("T")[0];
+    dateInput.value = iso;
+  }
+
+  if (timeInput) {
+    const now = new Date();
+    const hh = String(now.getHours()).padStart(2, "0");
+    const mm = String(now.getMinutes()).padStart(2, "0");
+    timeInput.value = `${hh}:${mm}`;
+  }
+
+  if (swapButton) {
+    swapButton.addEventListener("click", () => {
+      const fromValue = fromSelect.value;
+      fromSelect.value = toSelect.value;
+      toSelect.value = fromValue;
+      updateNotes();
+      resetResult();
+    });
+  }
+
+  fromSelect?.addEventListener("change", () => {
+    updateNotes();
+    resetResult();
+  });
+  toSelect?.addEventListener("change", () => {
+    updateNotes();
+    resetResult();
+  });
+
+  form.addEventListener("reset", () => {
+    window.requestAnimationFrame(() => {
+      if (statusEl) statusEl.textContent = "Pick airports to begin.";
+      if (resultEl) resultEl.innerHTML = "";
+      updateNotes();
+    });
+  });
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    if (!statusEl || !resultEl) return;
+
+    const fromAirport = airportMap.get(fromSelect.value || "");
+    const toAirport = airportMap.get(toSelect.value || "");
+    if (!fromAirport || !toAirport) {
+      statusEl.textContent = "Choose both departure and arrival airports.";
+      resultEl.innerHTML = "";
+      return;
+    }
+    if (fromAirport.code === toAirport.code) {
+      statusEl.textContent = "Departure and arrival airports must be different.";
+      resultEl.innerHTML = "";
+      return;
+    }
+
+    const dateParts = parseDateInput(dateInput?.value || "");
+    const timeParts = parseTimeInput(timeInput?.value || "");
+    if (!dateParts || !timeParts) {
+      statusEl.textContent = "Enter a valid departure date and time.";
+      resultEl.innerHTML = "";
+      return;
+    }
+
+    const speed = Number(speedInput?.value || "0");
+    if (!Number.isFinite(speed) || speed <= 0) {
+      statusEl.textContent = "Enter a cruise speed in km/h.";
+      resultEl.innerHTML = "";
+      return;
+    }
+
+    const departureUtc = zonedDateToUtc(
+      { ...dateParts, ...timeParts },
+      fromAirport.timeZone
+    );
+    const distanceKm = haversineDistance(
+      fromAirport.lat,
+      fromAirport.lon,
+      toAirport.lat,
+      toAirport.lon
+    );
+    const durationMinutes = (distanceKm / speed) * 60;
+    const arrivalUtc = new Date(departureUtc.getTime() + durationMinutes * 60000);
+
+    const distanceMiles = distanceKm * 0.621371;
+    const formattedDuration = formatDuration(durationMinutes);
+    const departureLocal = formatLocal(departureUtc, fromAirport.timeZone);
+    const arrivalLocal = formatLocal(arrivalUtc, toAirport.timeZone);
+    const depOffset = getOffset(departureUtc, fromAirport.timeZone);
+    const arrOffset = getOffset(arrivalUtc, toAirport.timeZone);
+    const tzDiffHours = (arrOffset - depOffset) / 60;
+
+    const tzDiffLabel =
+      tzDiffHours === 0
+        ? "No time zone change"
+        : tzDiffHours > 0
+        ? `${tzDiffHours.toFixed(1)} hour${Math.abs(tzDiffHours) === 1 ? "" : "s"} ahead`
+        : `${Math.abs(tzDiffHours).toFixed(1)} hour${Math.abs(tzDiffHours) === 1 ? "" : "s"} behind`;
+
+    const cruiseKnots = speed * 0.539957;
+
+    resultEl.innerHTML = `
+      <div class="card" style="margin-top:0;">
+        <h2 style="margin-top:0;">Estimated itinerary</h2>
+        <p class="helper">Distance is based on the great-circle route between airport coordinates.</p>
+        <ul class="result-list">
+          <li><strong>Distance:</strong> ${distanceKm.toFixed(0)} km (${distanceMiles.toFixed(
+      0
+    )} miles)</li>
+          <li><strong>Estimated duration:</strong> ${formattedDuration} at ${speed.toFixed(
+      0
+    )} km/h (${cruiseKnots.toFixed(0)} knots)</li>
+          <li><strong>Depart:</strong> ${departureLocal} (${formatOffsetLabel(depOffset)})</li>
+          <li><strong>Arrive:</strong> ${arrivalLocal} (${formatOffsetLabel(arrOffset)})</li>
+          <li><strong>Time zone shift:</strong> ${tzDiffLabel}</li>
+        </ul>
+      </div>
+    `;
+
+    statusEl.textContent = `Nonstop estimate: ${formattedDuration}. Adjust cruise speed for winds or ground time.`;
+  });
+})();

--- a/public/js/grade-calculator.js
+++ b/public/js/grade-calculator.js
@@ -1,0 +1,197 @@
+(function () {
+  if (typeof window === "undefined") return;
+
+  const gpaForm = document.getElementById("gpa-form");
+  const gpaStatus = document.getElementById("gpa-status");
+  const gpaResult = document.getElementById("gpa-result");
+  const finalForm = document.getElementById("final-form");
+  const finalStatus = document.getElementById("final-status");
+  const finalResult = document.getElementById("final-result");
+
+  if (!gpaForm || !finalForm) return;
+
+  const letterScale = [
+    { min: 3.85, label: "A" },
+    { min: 3.7, label: "A-" },
+    { min: 3.3, label: "B+" },
+    { min: 3.0, label: "B" },
+    { min: 2.7, label: "B-" },
+    { min: 2.3, label: "C+" },
+    { min: 2.0, label: "C" },
+    { min: 1.7, label: "C-" },
+    { min: 1.3, label: "D+" },
+    { min: 1.0, label: "D" },
+    { min: 0, label: "F" },
+  ];
+
+  function getLetterFromGpa(value) {
+    const rounded = Math.max(0, Math.min(4, value));
+    const match = letterScale.find((item) => rounded >= item.min);
+    return match ? match.label : "F";
+  }
+
+  function formatNumber(value, decimals = 2) {
+    return Number.isFinite(value) ? value.toFixed(decimals) : "—";
+  }
+
+  function handleGpaSubmit(event) {
+    event.preventDefault();
+    if (!gpaStatus || !gpaResult) return;
+
+    const current = Number(gpaForm.current.value);
+    const completed = Number(gpaForm.completed.value);
+    const target = Number(gpaForm.target.value);
+    const upcoming = Number(gpaForm.upcoming.value);
+
+    if (
+      !Number.isFinite(current) ||
+      !Number.isFinite(completed) ||
+      !Number.isFinite(target) ||
+      !Number.isFinite(upcoming) ||
+      completed < 0 ||
+      upcoming <= 0
+    ) {
+      gpaStatus.textContent = "Enter valid GPA values and credit hours.";
+      gpaResult.innerHTML = "";
+      return;
+    }
+
+    const cappedCurrent = Math.min(Math.max(current, 0), 4);
+    const cappedTarget = Math.min(Math.max(target, 0), 4);
+    const totalCredits = completed + upcoming;
+    const currentQuality = cappedCurrent * completed;
+    const targetQuality = cappedTarget * totalCredits;
+    const qualityNeeded = targetQuality - currentQuality;
+
+    if (qualityNeeded <= 0) {
+      gpaStatus.textContent = "You're already at or above the target GPA.";
+      gpaResult.innerHTML = `
+        <div class="card" style="margin-top:0;">
+          <h2 style="margin-top:0;">Great news</h2>
+          <p>Your existing GPA keeps you on track for a ${formatNumber(cappedTarget, 2)} goal.</p>
+        </div>
+      `;
+      return;
+    }
+
+    const requiredTermGpa = qualityNeeded / upcoming;
+    const achievable = requiredTermGpa <= 4.0;
+    const letter = getLetterFromGpa(requiredTermGpa);
+
+    gpaStatus.textContent = achievable
+      ? `You need an average GPA of ${formatNumber(requiredTermGpa, 2)} across the remaining ${upcoming.toLocaleString()} credits.`
+      : "The target GPA is out of reach with the credits remaining.";
+
+    const margin = achievable ? 4.0 - requiredTermGpa : 0;
+    const nextTarget = Math.min(requiredTermGpa + 0.25, 4.0);
+
+    gpaResult.innerHTML = `
+      <div class="card" style="margin-top:0;">
+        <h2 style="margin-top:0;">Required upcoming GPA</h2>
+        <ul class="result-list">
+          <li><strong>Needed GPA in remaining credits:</strong> ${formatNumber(requiredTermGpa, 2)} (${letter})</li>
+          <li><strong>Total quality points to earn:</strong> ${formatNumber(qualityNeeded, 2)}</li>
+          <li><strong>Credits remaining:</strong> ${upcoming.toLocaleString()}</li>
+          <li><strong>Credits completed:</strong> ${completed.toLocaleString()}</li>
+        </ul>
+        <p class="helper">
+          ${achievable
+            ? `You have a cushion of ${formatNumber(margin, 2)} GPA point${margin === 1 ? "" : "s"} before hitting a 4.0.`
+            : "Consider adding more credit hours or adjusting your target GPA."}
+        </p>
+        <p class="helper">Aim for ${formatNumber(nextTarget, 2)} or better each term to stay ahead of schedule.</p>
+      </div>
+    `;
+  }
+
+  function handleGpaReset() {
+    if (gpaStatus) gpaStatus.textContent = "Fill in your current stats to begin.";
+    if (gpaResult) gpaResult.innerHTML = "";
+  }
+
+  function handleFinalSubmit(event) {
+    event.preventDefault();
+    if (!finalStatus || !finalResult) return;
+
+    const current = Number(finalForm.current.value);
+    const weightPercent = Number(finalForm.weight.value);
+    const target = Number(finalForm.target.value);
+    const floor = finalForm.floor.value ? Number(finalForm.floor.value) : null;
+
+    if (
+      !Number.isFinite(current) ||
+      !Number.isFinite(weightPercent) ||
+      !Number.isFinite(target) ||
+      weightPercent <= 0 ||
+      weightPercent > 100
+    ) {
+      finalStatus.textContent = "Enter valid grade percentages and exam weight.";
+      finalResult.innerHTML = "";
+      return;
+    }
+
+    const weight = weightPercent / 100;
+    const remainingWeight = 1 - weight;
+    const requiredExam = (target - current * remainingWeight) / weight;
+    const cappedRequired = Math.max(Math.min(requiredExam, 150), -50);
+
+    let outcome;
+    if (requiredExam > 100) {
+      outcome = `Even a 100% on the final would finish at ${formatNumber(
+        current * remainingWeight + 100 * weight,
+        1
+      )}%. Consider adjusting your target or grading weights.`;
+    } else if (requiredExam < 0) {
+      outcome = "You could skip the final and still meet your target—though we don't recommend it!";
+    } else {
+      outcome = `You need about ${formatNumber(cappedRequired, 1)}% on the final exam to earn ${formatNumber(
+        target,
+        1
+      )}%.`;
+    }
+
+    const floorNote =
+      floor !== null && Number.isFinite(floor)
+        ? requiredExam >= floor
+          ? `Aiming for ${formatNumber(floor, 1)}% keeps you above your personal minimum.`
+          : `Your minimum of ${formatNumber(floor, 1)}% would land at ${formatNumber(
+              current * remainingWeight + floor * weight,
+              1
+            )}%.`
+        : "";
+
+    const finalGradeIfAverage = current * remainingWeight + Math.max(Math.min(requiredExam, 100), 0) * weight;
+
+    finalStatus.textContent = outcome;
+    finalResult.innerHTML = `
+      <div class="card" style="margin-top:0;">
+        <h2 style="margin-top:0;">Final exam breakdown</h2>
+        <ul class="result-list">
+          <li><strong>Current average (weighted so far):</strong> ${formatNumber(current, 1)}%</li>
+          <li><strong>Final exam weight:</strong> ${formatNumber(weightPercent, 1)}%</li>
+          <li><strong>Required exam score:</strong> ${formatNumber(Math.max(requiredExam, 0), 1)}%</li>
+          <li><strong>Projected overall grade (if exam hits the target):</strong> ${formatNumber(
+            finalGradeIfAverage,
+            1
+          )}%</li>
+        </ul>
+        ${floorNote ? `<p class="helper">${floorNote}</p>` : ""}
+        <p class="helper">Double-check with your syllabus—different schools round grades differently.</p>
+      </div>
+    `;
+  }
+
+  function handleFinalReset() {
+    if (finalStatus) finalStatus.textContent = "Enter course details to see the required score.";
+    if (finalResult) finalResult.innerHTML = "";
+  }
+
+  gpaForm.addEventListener("submit", handleGpaSubmit);
+  gpaForm.addEventListener("reset", () => {
+    window.requestAnimationFrame(handleGpaReset);
+  });
+  finalForm.addEventListener("submit", handleFinalSubmit);
+  finalForm.addEventListener("reset", () => {
+    window.requestAnimationFrame(handleFinalReset);
+  });
+})();

--- a/public/js/meal-planner.js
+++ b/public/js/meal-planner.js
@@ -1,0 +1,180 @@
+(function () {
+  if (typeof window === "undefined") return;
+
+  const form = document.getElementById("meal-form");
+  const statusEl = document.getElementById("meal-status");
+  const resultEl = document.getElementById("meal-result");
+
+  if (!form || !statusEl || !resultEl) return;
+
+  const STYLE_MULTIPLIERS = {
+    light: 0.85,
+    standard: 1,
+    hearty: 1.2,
+  };
+
+  const DEFAULT_CHILD_FACTOR = 0.6;
+
+  const COURSES = {
+    protein: {
+      label: "Main protein",
+      portionPerAdult: 6, // ounces cooked
+      format(totalUnits, servings) {
+        const pounds = totalUnits / 16;
+        const kilograms = pounds * 0.45359237;
+        return {
+          primary: `${pounds.toFixed(1)} lb cooked (${kilograms.toFixed(2)} kg)`,
+          secondary: `Plan for about ${Math.ceil(servings)} plated portions at 6 oz cooked each.`,
+        };
+      },
+    },
+    grains: {
+      label: "Starch / grains",
+      portionPerAdult: 4.5, // ounces cooked
+      format(totalUnits, servings) {
+        const cups = totalUnits / 5;
+        const pounds = totalUnits / 16;
+        return {
+          primary: `${cups.toFixed(1)} cups cooked sides (~${pounds.toFixed(1)} lb)`,
+          secondary: `Enough for roughly ${Math.ceil(servings)} people at a generous scoop.`,
+        };
+      },
+    },
+    vegetables: {
+      label: "Cooked vegetables",
+      portionPerAdult: 1.25, // cups cooked
+      format(totalUnits, servings) {
+        const pounds = totalUnits * 0.24; // approximate conversion from cups to pounds fresh
+        return {
+          primary: `${totalUnits.toFixed(1)} cups cooked veggies (~${pounds.toFixed(1)} lb fresh)`,
+          secondary: `Consider prepping ${Math.ceil(servings)} ramekins or side portions.`,
+        };
+      },
+    },
+    salad: {
+      label: "Salad",
+      portionPerAdult: 1.5, // cups of greens
+      format(totalUnits) {
+        const bowls = totalUnits / 10; // 10 cups per large salad bowl
+        const bags = totalUnits / 5; // 5 cups per bag of mixed greens
+        return {
+          primary: `${totalUnits.toFixed(1)} cups of greens`,
+          secondary: `≈${Math.ceil(bowls)} large serving bowls or ${Math.ceil(bags)} bags of salad mix.`,
+        };
+      },
+    },
+    dessert: {
+      label: "Dessert servings",
+      portionPerAdult: 1,
+      format(totalUnits) {
+        const dozens = totalUnits / 12;
+        return {
+          primary: `${Math.ceil(totalUnits)} individual desserts`,
+          secondary: `That's about ${Math.ceil(dozens)} dozen pieces for trays or platters.`,
+        };
+      },
+    },
+    drinks: {
+      label: "Drinks",
+      portionPerAdult: 16, // fluid ounces
+      format(totalUnits) {
+        const gallons = totalUnits / 128;
+        const liters = totalUnits * 0.0295735;
+        const servings = totalUnits / 12; // 12 oz cups
+        return {
+          primary: `${gallons.toFixed(1)} gallons (${liters.toFixed(1)} L) of beverages`,
+          secondary: `Covers roughly ${Math.ceil(servings)} 12-oz pours (water, punch, or soft drinks).`,
+        };
+      },
+    },
+  };
+
+  function formatNumber(value) {
+    return Number.isFinite(value) ? value.toFixed(1).replace(/\.0$/, "") : "0";
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+
+    const adults = Number(form.adults.value) || 0;
+    const kids = Number(form.kids.value) || 0;
+    const style = form.style.value || "standard";
+    const leftoversPercent = Number(form.leftovers.value) || 0;
+    const selectedCourses = Array.from(form.querySelectorAll('input[name="course"]:checked')).map(
+      (input) => input.value
+    );
+
+    if (adults <= 0 && kids <= 0) {
+      statusEl.textContent = "Add at least one adult or child to calculate portions.";
+      resultEl.innerHTML = "";
+      return;
+    }
+
+    if (selectedCourses.length === 0) {
+      statusEl.textContent = "Select at least one course to include in the plan.";
+      resultEl.innerHTML = "";
+      return;
+    }
+
+    const childEquivalent = kids * DEFAULT_CHILD_FACTOR;
+    const baseEquivalent = adults + childEquivalent;
+    const styleMultiplier = STYLE_MULTIPLIERS[style] || 1;
+    const leftoverMultiplier = 1 + Math.max(leftoversPercent, 0) / 100;
+    const adjustedServings = baseEquivalent * styleMultiplier * leftoverMultiplier;
+
+    const rows = selectedCourses.map((courseId) => {
+      const course = COURSES[courseId];
+      if (!course) return null;
+      const totalUnits = adjustedServings * course.portionPerAdult;
+      const summary = course.format(totalUnits, adjustedServings);
+      return `
+        <tr>
+          <td>${course.label}</td>
+          <td><strong>${summary.primary}</strong><br><span class="helper">${summary.secondary}</span></td>
+        </tr>
+      `;
+    });
+
+    const includedLabels = selectedCourses
+      .map((id) => COURSES[id]?.label || id)
+      .filter(Boolean)
+      .join(", ");
+
+    statusEl.textContent = `Plan for ${Math.ceil(adjustedServings)} adult-equivalent servings across ${selectedCourses.length} course${
+      selectedCourses.length === 1 ? "" : "s"
+    }.`;
+
+    resultEl.innerHTML = `
+      <div class="card" style="margin-top:0;">
+        <h2 style="margin-top:0;">Portion overview</h2>
+        <ul class="result-list">
+          <li><strong>Adults:</strong> ${adults.toLocaleString()}</li>
+          <li><strong>Children:</strong> ${kids.toLocaleString()} (≈${formatNumber(childEquivalent)} adult servings)</li>
+          <li><strong>Meal style multiplier:</strong> ${styleMultiplier.toFixed(2)} (${style})</li>
+          <li><strong>Leftover buffer:</strong> ${formatNumber(leftoverMultiplier * 100 - 100)}%</li>
+          <li><strong>Total adult-equivalent servings:</strong> ${formatNumber(adjustedServings)}</li>
+          <li><strong>Courses included:</strong> ${includedLabels}</li>
+        </ul>
+        <table class="table" style="width:100%; margin-top:16px;">
+          <tbody>
+            ${rows.filter(Boolean).join("")}
+          </tbody>
+        </table>
+        <p class="helper">
+          Adjust the leftover buffer down for plated meals or up for buffet-style service. For specialty diets, create a second
+          run with only the dishes that apply.
+        </p>
+      </div>
+    `;
+  }
+
+  function handleReset() {
+    statusEl.textContent = "Enter your headcount to size the meal.";
+    resultEl.innerHTML = "";
+  }
+
+  form.addEventListener("submit", handleSubmit);
+  form.addEventListener("reset", () => {
+    window.requestAnimationFrame(handleReset);
+  });
+})();

--- a/public/js/pdf-to-word.js
+++ b/public/js/pdf-to-word.js
@@ -1,0 +1,206 @@
+(function () {
+  if (typeof window === "undefined") return;
+
+  const form = document.getElementById("pdf-form");
+  const fileInput = document.getElementById("pdf-file");
+  const statusEl = document.getElementById("pdf-status");
+  const output = document.getElementById("pdf-output");
+  const downloadWord = document.getElementById("pdf-download-word");
+  const downloadText = document.getElementById("pdf-download-text");
+  const copyButton = document.getElementById("pdf-copy");
+  const charCountEl = document.getElementById("pdf-char-count");
+  const wordCountEl = document.getElementById("pdf-word-count");
+  const lineCountEl = document.getElementById("pdf-line-count");
+
+  if (!form || !fileInput || !output) return;
+
+  let baseFilename = "extracted-text";
+
+  function setButtonsEnabled(enabled) {
+    const state = !enabled;
+    if (downloadWord) downloadWord.disabled = state;
+    if (downloadText) downloadText.disabled = state;
+    if (copyButton) copyButton.disabled = state;
+  }
+
+  function decodePdfString(value) {
+    if (!value) return "";
+    return value
+      .replace(/\\([0-7]{1,3})/g, (_, octal) => String.fromCharCode(parseInt(octal, 8)))
+      .replace(/\\r/g, "\n")
+      .replace(/\\n/g, "\n")
+      .replace(/\\t/g, "\t")
+      .replace(/\\f/g, "")
+      .replace(/\\b/g, "")
+      .replace(/\\\(/g, "(")
+      .replace(/\\\)/g, ")")
+      .replace(/\\\\/g, "\\");
+  }
+
+  function extractTextFromArray(arrayContent) {
+    const parts = [];
+    const regex = /\(([^()]*?(?:\\.[^()]*)*)\)/g;
+    let match;
+    while ((match = regex.exec(arrayContent))) {
+      parts.push(decodePdfString(match[1]));
+    }
+    return parts.join("");
+  }
+
+  function extractPdfText(buffer) {
+    const bytes = new Uint8Array(buffer);
+    const decoder = new TextDecoder("latin1");
+    const raw = decoder.decode(bytes);
+    const textChunks = [];
+
+    const directRegex = /\(([^()]*?(?:\\.[^()]*)*)\)\s*Tj/g;
+    let match;
+    while ((match = directRegex.exec(raw))) {
+      textChunks.push(decodePdfString(match[1]));
+    }
+
+    const arrayRegex = /\[([^\]]+)\]\s*TJ/g;
+    while ((match = arrayRegex.exec(raw))) {
+      textChunks.push(extractTextFromArray(match[1]));
+    }
+
+    if (textChunks.length === 0) {
+      // Fallback to collect any strings even if operators weren't matched.
+      const looseRegex = /\(([^()]*?(?:\\.[^()]*)*)\)/g;
+      while ((match = looseRegex.exec(raw))) {
+        textChunks.push(decodePdfString(match[1]));
+      }
+    }
+
+    let combined = textChunks.join("");
+    combined = combined.replace(/\r\n?/g, "\n");
+    combined = combined.replace(/\u0000/g, "");
+    combined = combined.replace(/\n{3,}/g, "\n\n");
+    combined = combined.replace(/([^\s])\n(?!\n)/g, "$1\n");
+    return combined.trim();
+  }
+
+  function updateStats() {
+    const text = output.value || "";
+    const words = text.trim() ? text.trim().split(/\s+/).length : 0;
+    const chars = text.length;
+    const lines = text ? text.split(/\n/).length : 0;
+    if (wordCountEl) wordCountEl.textContent = words.toLocaleString();
+    if (charCountEl) charCountEl.textContent = chars.toLocaleString();
+    if (lineCountEl) lineCountEl.textContent = lines.toLocaleString();
+    setButtonsEnabled(Boolean(text));
+  }
+
+  function downloadBlob(filename, type, data) {
+    const blob = new Blob([data], { type });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+
+  function downloadAsWord() {
+    const text = output.value.trim();
+    if (!text) return;
+    const paragraphs = text.split(/\n{2,}/).map((para) => para.trim());
+    const htmlBody = paragraphs
+      .map((para) => {
+        const safe = para.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+        return `<p>${safe.replace(/\n/g, "<br>")}</p>`;
+      })
+      .join("");
+    const html = `<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>${htmlBody}</body></html>`;
+    downloadBlob(`${baseFilename}.doc`, "application/msword", html);
+  }
+
+  function downloadAsText() {
+    const text = output.value;
+    if (!text) return;
+    downloadBlob(`${baseFilename}.txt`, "text/plain;charset=utf-8", text);
+  }
+
+  async function copyText() {
+    if (!output.value) return;
+    if (!navigator.clipboard || !navigator.clipboard.writeText) {
+      if (statusEl)
+        statusEl.textContent = "Clipboard unavailable—select the text and copy manually.";
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(output.value);
+      if (statusEl) statusEl.textContent = "Copied extracted text to your clipboard.";
+    } catch (error) {
+      if (statusEl) statusEl.textContent = "Copy failed—select the text manually.";
+    }
+  }
+
+  async function handleFileChange() {
+    const file = fileInput.files && fileInput.files[0];
+    if (!file) {
+      output.value = "";
+      updateStats();
+      if (statusEl)
+        statusEl.textContent = "Select a reasonably small text-based PDF (forms and scanned images may not extract cleanly).";
+      return;
+    }
+
+    baseFilename = file.name.replace(/\.pdf$/i, "") || "extracted-text";
+    if (statusEl) statusEl.textContent = "Reading PDF…";
+    setButtonsEnabled(false);
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      try {
+        const buffer = event.target?.result;
+        if (!(buffer instanceof ArrayBuffer)) {
+          throw new Error("Unsupported file result");
+        }
+        const text = extractPdfText(buffer);
+        output.value = text;
+        updateStats();
+        if (statusEl) {
+          statusEl.textContent = text
+            ? "Extraction complete. Review and edit as needed before downloading."
+            : "No text blocks were found. The PDF may be image-based or heavily formatted.";
+        }
+      } catch (error) {
+        output.value = "";
+        updateStats();
+        if (statusEl)
+          statusEl.textContent = "Something went wrong while parsing—try another PDF or a smaller file.";
+      }
+    };
+    reader.onerror = () => {
+      output.value = "";
+      updateStats();
+      if (statusEl)
+        statusEl.textContent = "Unable to read the PDF. Make sure the file isn't encrypted.";
+    };
+    reader.readAsArrayBuffer(file);
+  }
+
+  fileInput.addEventListener("change", handleFileChange);
+  output.addEventListener("input", () => {
+    updateStats();
+    if (statusEl) statusEl.textContent = "Edited text won't affect your original PDF.";
+  });
+  downloadWord?.addEventListener("click", downloadAsWord);
+  downloadText?.addEventListener("click", downloadAsText);
+  copyButton?.addEventListener("click", copyText);
+
+  form.addEventListener("reset", () => {
+    window.requestAnimationFrame(() => {
+      output.value = "";
+      setButtonsEnabled(false);
+      updateStats();
+      if (statusEl)
+        statusEl.textContent = "Select a reasonably small text-based PDF (forms and scanned images may not extract cleanly).";
+    });
+  });
+
+  updateStats();
+})();

--- a/public/js/pet-age-converter.js
+++ b/public/js/pet-age-converter.js
@@ -1,0 +1,154 @@
+(function () {
+  if (typeof window === "undefined") return;
+
+  const form = document.getElementById("pet-age-form");
+  const resultEl = document.getElementById("pet-age-result");
+  const referenceEl = document.getElementById("pet-reference");
+
+  if (!form || !resultEl || !referenceEl) return;
+
+  const speciesModels = {
+    dog: {
+      label: "Dog",
+      petToHuman(age) {
+        if (age <= 0) return 0;
+        let years = 0;
+        if (age >= 1) {
+          years += 15;
+          age -= 1;
+        } else {
+          return age * 15;
+        }
+        if (age >= 1) {
+          years += 9;
+          age -= 1;
+        } else {
+          return years + age * 9;
+        }
+        return years + age * 5;
+      },
+      humanToPet(age) {
+        if (age <= 0) return 0;
+        if (age <= 15) return age / 15;
+        if (age <= 24) return 1 + (age - 15) / 9;
+        return 2 + (age - 24) / 5;
+      },
+    },
+    cat: {
+      label: "Cat",
+      petToHuman(age) {
+        if (age <= 0) return 0;
+        let years = 0;
+        if (age >= 1) {
+          years += 15;
+          age -= 1;
+        } else {
+          return age * 15;
+        }
+        if (age >= 1) {
+          years += 9;
+          age -= 1;
+        } else {
+          return years + age * 9;
+        }
+        return years + age * 4;
+      },
+      humanToPet(age) {
+        if (age <= 0) return 0;
+        if (age <= 15) return age / 15;
+        if (age <= 24) return 1 + (age - 15) / 9;
+        return 2 + (age - 24) / 4;
+      },
+    },
+  };
+
+  function getLifeStage(humanAge) {
+    if (humanAge < 12) return "Puppy/kitten";
+    if (humanAge < 20) return "Young adolescent";
+    if (humanAge < 35) return "Young adult";
+    if (humanAge < 55) return "Adult";
+    if (humanAge < 70) return "Mature";
+    return "Senior";
+  }
+
+  function formatYears(value) {
+    return value.toFixed(1).replace(/\.0$/, "");
+  }
+
+  function renderResult({ species, direction, inputAge, converted }) {
+    const humanYears = direction === "pet-to-human" ? converted : inputAge;
+    const stage = getLifeStage(humanYears);
+    const targetLabel = direction === "pet-to-human" ? "Human years" : `${speciesModels[species].label} years`;
+    const inputLabel = direction === "pet-to-human" ? `${speciesModels[species].label} years` : "Human years";
+    return `
+      <div class="card" style="margin-top:0;">
+        <h2 style="margin-top:0;">Conversion result</h2>
+        <ul class="result-list">
+          <li><strong>${inputLabel}:</strong> ${formatYears(inputAge)}</li>
+          <li><strong>${targetLabel}:</strong> ${formatYears(converted)}</li>
+          <li><strong>Life stage estimate:</strong> ${stage}</li>
+        </ul>
+        <p class="helper">Always factor in breed size, health, and vet guidance for more precise care recommendations.</p>
+      </div>
+    `;
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    const species = form.species.value;
+    const direction = form.direction.value;
+    const age = Number(form.age.value);
+    if (!speciesModels[species] || !Number.isFinite(age) || age < 0) {
+      resultEl.innerHTML = "<p class=\"helper\">Enter a non-negative age to see the conversion.</p>";
+      return;
+    }
+
+    let converted;
+    if (direction === "pet-to-human") {
+      converted = speciesModels[species].petToHuman(age);
+    } else {
+      converted = speciesModels[species].humanToPet(age);
+    }
+
+    resultEl.innerHTML = renderResult({ species, direction, inputAge: age, converted });
+  }
+
+  function buildReference() {
+    const sampleAges = [1, 2, 3, 5, 7, 10, 12, 15];
+    const humanMilestones = [5, 10, 18, 30, 45, 60, 75];
+    const pieces = [];
+
+    Object.entries(speciesModels).forEach(([key, model]) => {
+      const petToHumanRows = sampleAges
+        .map((age) => `<li>${age} ${age === 1 ? "year" : "years"} → ${formatYears(model.petToHuman(age))} human years`)
+        .join("</li><li>");
+      const humanToPetRows = humanMilestones
+        .map(
+          (age) =>
+            `${age} human years → ${formatYears(model.humanToPet(age))} ${model.label.toLowerCase()} years`
+        )
+        .join("</li><li>");
+      pieces.push(`
+        <div class="card" style="margin-top:0;">
+          <h3 style="margin-top:0;">${model.label} reference</h3>
+          <p class="helper">Approximate conversions using a medium-size ${model.label.toLowerCase()} growth curve.</p>
+          <p class="helper"><strong>Pet → Human</strong></p>
+          <ul class="result-list"><li>${petToHumanRows}</li></ul>
+          <p class="helper"><strong>Human → ${model.label}</strong></p>
+          <ul class="result-list"><li>${humanToPetRows}</li></ul>
+        </div>
+      `);
+    });
+
+    referenceEl.innerHTML = pieces.join("");
+  }
+
+  form.addEventListener("submit", handleSubmit);
+  form.addEventListener("reset", () => {
+    window.requestAnimationFrame(() => {
+      resultEl.innerHTML = "";
+    });
+  });
+
+  buildReference();
+})();

--- a/public/js/typing-speed-test.js
+++ b/public/js/typing-speed-test.js
@@ -1,0 +1,196 @@
+(function () {
+  if (typeof window === "undefined") return;
+
+  const promptBank = {
+    paragraph: [
+      "Typing quickly comes from practicing proper technique and keeping a steady rhythm.",
+      "Set a timer, take a deep breath, and focus on accuracy before pushing for speed.",
+      "Consistency beats intensity—short bursts of deliberate practice deliver the best improvements.",
+      "Writers often warm up with free-flowing paragraphs to loosen their fingers and clear their minds.",
+      "Track your progress each week so you can celebrate the small gains that add up over time.",
+    ],
+    quotes: [
+      "The secret of getting ahead is getting started.",
+      "Perfection is not attainable, but if we chase perfection we can catch excellence.",
+      "Success is the sum of small efforts, repeated day in and day out.",
+      "Quality is not an act, it is a habit.",
+      "The future depends on what you do today.",
+    ],
+    numbers: [
+      "123 456 789 0 + - = * 321 654 987",
+      "2024 / 07 / 04 – deadlines, budgets, 15% growth goals",
+      "Call 555-0102 at 9:45 AM, then send 12 invoices for $175 each.",
+      "Invoice #1048 totals $2,987.43 after a 6.5% state tax.",
+      "9 + 10 = 19, but 9 × 10 = 90—double-check the symbols!",
+    ],
+  };
+
+  const settingsForm = document.getElementById("typing-settings");
+  const startButton = document.getElementById("typing-start");
+  const resetButton = document.getElementById("typing-reset");
+  const durationSelect = document.getElementById("typing-duration");
+  const modeSelect = document.getElementById("typing-mode");
+  const statusEl = document.getElementById("typing-status");
+  const promptEl = document.getElementById("typing-prompt");
+  const inputEl = document.getElementById("typing-input");
+  const timerEl = document.getElementById("typing-timer");
+  const errorsEl = document.getElementById("typing-errors");
+  const wpmEl = document.getElementById("typing-wpm");
+  const grossEl = document.getElementById("typing-gross");
+  const accuracyEl = document.getElementById("typing-accuracy");
+  const charsEl = document.getElementById("typing-chars");
+  const correctEl = document.getElementById("typing-correct");
+  const missedEl = document.getElementById("typing-missed");
+
+  if (!settingsForm || !startButton || !inputEl) return;
+
+  let timerId = null;
+  let targetText = "";
+  let duration = 60;
+  let startTime = 0;
+  let running = false;
+  let elapsedSeconds = 0;
+
+  function pickPrompt(mode) {
+    const choices = promptBank[mode] || promptBank.paragraph;
+    const index = Math.floor(Math.random() * choices.length);
+    return choices[index];
+  }
+
+  function formatClock(seconds) {
+    const safe = Math.max(0, Math.ceil(seconds));
+    const mm = String(Math.floor(safe / 60)).padStart(2, "0");
+    const ss = String(safe % 60).padStart(2, "0");
+    return `${mm}:${ss}`;
+  }
+
+  function countWords(value) {
+    const trimmed = value.trim();
+    if (!trimmed) return 0;
+    return trimmed.split(/\s+/).length;
+  }
+
+  function updateStats() {
+    const typed = inputEl.value;
+    const now = running ? Date.now() : startTime + elapsedSeconds * 1000;
+    elapsedSeconds = running ? Math.min((now - startTime) / 1000, duration) : elapsedSeconds;
+    const minutes = elapsedSeconds / 60 || 1 / 60;
+
+    let correct = 0;
+    const compareLength = Math.min(typed.length, targetText.length);
+    for (let i = 0; i < compareLength; i += 1) {
+      if (typed[i] === targetText[i]) correct += 1;
+    }
+    const mistakes = Math.max(typed.length - correct, 0);
+    const grossWPM = minutes > 0 ? (typed.length / 5) / minutes : 0;
+    const errorPenalty = minutes > 0 ? mistakes / 5 / minutes : 0;
+    const netWPM = Math.max(grossWPM - errorPenalty, 0);
+    const accuracy = typed.length > 0 ? (correct / typed.length) * 100 : 100;
+
+    if (wpmEl) wpmEl.textContent = netWPM.toFixed(1);
+    if (grossEl) grossEl.textContent = grossWPM.toFixed(1);
+    if (accuracyEl) accuracyEl.textContent = `${accuracy.toFixed(1)}%`;
+    if (charsEl) charsEl.textContent = typed.length.toString();
+    if (correctEl) correctEl.textContent = correct.toString();
+    if (missedEl) missedEl.textContent = mistakes.toString();
+    if (errorsEl) errorsEl.textContent = mistakes.toString();
+  }
+
+  function stopTimer() {
+    if (timerId) {
+      window.clearInterval(timerId);
+      timerId = null;
+    }
+  }
+
+  function finishTest() {
+    running = false;
+    stopTimer();
+    elapsedSeconds = duration;
+    if (timerEl) timerEl.textContent = formatClock(0);
+    inputEl.disabled = true;
+    updateStats();
+    if (statusEl) statusEl.textContent = "Time! Review your stats, then reset to try again.";
+  }
+
+  function tick() {
+    if (!running) return;
+    const now = Date.now();
+    const elapsed = (now - startTime) / 1000;
+    elapsedSeconds = Math.min(elapsed, duration);
+    const remaining = Math.max(duration - elapsed, 0);
+    if (timerEl) timerEl.textContent = formatClock(remaining);
+    updateStats();
+    if (remaining <= 0) {
+      finishTest();
+    }
+  }
+
+  function startTest() {
+    targetText = pickPrompt(modeSelect?.value || "paragraph");
+    if (promptEl) promptEl.textContent = targetText;
+    inputEl.value = "";
+    inputEl.disabled = false;
+    inputEl.focus();
+    duration = Number(durationSelect?.value || 60) || 60;
+    elapsedSeconds = 0;
+    startTime = Date.now();
+    running = true;
+    if (timerEl) timerEl.textContent = formatClock(duration);
+    if (statusEl)
+      statusEl.textContent = `Timer running for ${(duration / 60).toFixed(1)} minute${
+        duration === 60 ? "" : "s"
+      }. Stay relaxed and focus on accuracy.`;
+    stopTimer();
+    timerId = window.setInterval(tick, 200);
+    updateStats();
+  }
+
+  function resetTest() {
+    running = false;
+    stopTimer();
+    elapsedSeconds = 0;
+    inputEl.value = "";
+    inputEl.disabled = true;
+    if (promptEl) promptEl.textContent = "Prompt text will appear here.";
+    if (timerEl) timerEl.textContent = "00:00";
+    if (statusEl) statusEl.textContent = "Press “Start test” to load a prompt and begin the timer.";
+    if (wpmEl) wpmEl.textContent = "0";
+    if (grossEl) grossEl.textContent = "0";
+    if (accuracyEl) accuracyEl.textContent = "100%";
+    if (charsEl) charsEl.textContent = "0";
+    if (correctEl) correctEl.textContent = "0";
+    if (missedEl) missedEl.textContent = "0";
+    if (errorsEl) errorsEl.textContent = "0";
+  }
+
+  startButton.addEventListener("click", () => {
+    startTest();
+  });
+
+  resetButton?.addEventListener("click", () => {
+    resetTest();
+  });
+
+  settingsForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+  });
+
+  inputEl.addEventListener("input", () => {
+    if (!running) {
+      return;
+    }
+    updateStats();
+  });
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden && running) {
+      stopTimer();
+    } else if (!document.hidden && running && !timerId) {
+      startTime = Date.now() - elapsedSeconds * 1000;
+      timerId = window.setInterval(tick, 200);
+    }
+  });
+
+  resetTest();
+})();

--- a/public/js/word-counter.js
+++ b/public/js/word-counter.js
@@ -1,0 +1,132 @@
+(function () {
+  if (typeof window === "undefined") return;
+
+  const form = document.getElementById("word-counter-form");
+  const input = document.getElementById("word-counter-input");
+  const targetInput = document.getElementById("word-target");
+  const readingInput = document.getElementById("word-reading-speed");
+  const copyButton = document.getElementById("word-copy");
+  const wordEl = document.getElementById("word-total");
+  const charEl = document.getElementById("char-total");
+  const charTightEl = document.getElementById("char-tight");
+  const sentenceEl = document.getElementById("sentence-total");
+  const paragraphEl = document.getElementById("paragraph-total");
+  const readingEl = document.getElementById("reading-time");
+  const progressEl = document.getElementById("word-target-progress");
+
+  if (!form || !input) return;
+
+  function safeNumber(value) {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : 0;
+  }
+
+  function countParagraphs(text) {
+    const trimmed = text.trim();
+    if (!trimmed) return 0;
+    const parts = trimmed.split(/\n{2,}/);
+    return parts.filter((part) => part.trim().length > 0).length;
+  }
+
+  function countSentences(text) {
+    const cleaned = text.replace(/\s+/g, " ").trim();
+    if (!cleaned) return 0;
+    const parts = cleaned.split(/[.!?]+/);
+    return parts.filter((part) => part.trim().length > 0).length;
+  }
+
+  function countWords(text) {
+    const trimmed = text.trim();
+    if (!trimmed) return 0;
+    return trimmed.split(/\s+/).filter(Boolean).length;
+  }
+
+  function countCharactersWithoutWhitespace(text) {
+    return text.replace(/\s+/g, "").length;
+  }
+
+  function formatReadingTime(words, wpm) {
+    if (words <= 0 || wpm <= 0) return "0 min";
+    const totalMinutes = words / wpm;
+    let minutes = Math.floor(totalMinutes);
+    let seconds = Math.round((totalMinutes - minutes) * 60);
+    if (seconds === 60) {
+      minutes += 1;
+      seconds = 0;
+    }
+    const minuteLabel = minutes > 0 ? `${minutes} min` : "";
+    const secondLabel = seconds > 0 ? `${seconds} sec` : "";
+    return [minuteLabel, secondLabel].filter(Boolean).join(" ") || "0 min";
+  }
+
+  function updateStats() {
+    const text = input.value;
+    const wordCount = countWords(text);
+    const characters = text.length;
+    const charactersTight = countCharactersWithoutWhitespace(text);
+    const sentences = countSentences(text);
+    const paragraphs = countParagraphs(text);
+    const readingSpeed = Math.max(safeNumber(readingInput?.value), 1);
+    const readingTime = formatReadingTime(wordCount, readingSpeed);
+
+    if (wordEl) wordEl.textContent = wordCount.toLocaleString();
+    if (charEl) charEl.textContent = characters.toLocaleString();
+    if (charTightEl) charTightEl.textContent = charactersTight.toLocaleString();
+    if (sentenceEl) sentenceEl.textContent = sentences.toLocaleString();
+    if (paragraphEl) paragraphEl.textContent = paragraphs.toLocaleString();
+    if (readingEl) readingEl.textContent = readingTime;
+
+    const target = safeNumber(targetInput?.value);
+    if (target > 0 && progressEl) {
+      const progress = Math.min(100, (wordCount / target) * 100);
+      const remaining = Math.max(target - wordCount, 0);
+      const status =
+        remaining > 0
+          ? `${progress.toFixed(1)}% of ${target.toLocaleString()} words · ${remaining.toLocaleString()} to go`
+          : `Target met! ${wordCount.toLocaleString()} words`;
+      progressEl.textContent = `Word goal progress: ${status}`;
+    } else if (progressEl) {
+      progressEl.textContent = "";
+    }
+
+    if (copyButton) {
+      copyButton.disabled = !text;
+    }
+  }
+
+  input.addEventListener("input", updateStats);
+  targetInput?.addEventListener("input", updateStats);
+  readingInput?.addEventListener("input", updateStats);
+
+  copyButton?.addEventListener("click", async () => {
+    if (!input.value) return;
+    if (!navigator.clipboard || !navigator.clipboard.writeText) {
+      if (progressEl) {
+        progressEl.textContent = "Clipboard unavailable—select the text and copy manually.";
+      }
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(input.value);
+      if (progressEl) {
+        const previous = progressEl.textContent;
+        progressEl.textContent = "Copied to clipboard.";
+        window.setTimeout(() => {
+          progressEl.textContent = previous || "";
+        }, 1500);
+      }
+    } catch (error) {
+      if (progressEl) {
+        progressEl.textContent = "Copy failed—select the text manually.";
+      }
+    }
+  });
+
+  form.addEventListener("reset", () => {
+    window.requestAnimationFrame(() => {
+      updateStats();
+    });
+  });
+
+  updateStats();
+})();

--- a/src/lib/calculatorData.ts
+++ b/src/lib/calculatorData.ts
@@ -49,6 +49,13 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Holidays",
         description: "See days remaining until major U.S. holidays.",
       },
+      {
+        href: "/calculators/flight-time-calculator",
+        name: "Flight Time Calculator",
+        navLabel: "Flight Time",
+        description:
+          "Estimate nonstop duration, arrival time, and time zone shifts between major airports.",
+      },
     ],
   },
   {
@@ -160,6 +167,13 @@ export const calculatorCategories: CalculatorCategory[] = [
         description:
           "Quickly find tip amounts and per-person totals for the table.",
       },
+      {
+        href: "/calculators/event-budget-calculator",
+        name: "Event Budget Planner",
+        navLabel: "Event Budget",
+        description:
+          "Forecast venue, catering, staffing, and contingency costs with per-guest totals for any event.",
+      },
     ],
   },
   {
@@ -214,6 +228,13 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Clothing",
         description:
           "Find approximate international equivalents for common men's and women's apparel sizes.",
+      },
+      {
+        href: "/calculators/pet-age-converter",
+        name: "Pet Age Converter",
+        navLabel: "Pet Age",
+        description:
+          "Translate cat and dog ages into human years (and back) with growth-stage context.",
       },
     ],
   },
@@ -283,6 +304,41 @@ export const calculatorCategories: CalculatorCategory[] = [
         name: "QR Code Generator",
         navLabel: "QR Code",
         description: "Turn any text or link into a downloadable QR code with adjustable size.",
+      },
+      {
+        href: "/calculators/typing-speed-test",
+        name: "Typing Speed Test",
+        navLabel: "Typing Test",
+        description:
+          "Measure words per minute, accuracy, and keystrokes with live stats during timed prompts.",
+      },
+      {
+        href: "/calculators/word-counter",
+        name: "Word & Character Counter",
+        navLabel: "Word Counter",
+        description:
+          "Track words, characters, sentences, and reading time while you draft or edit text.",
+      },
+      {
+        href: "/calculators/pdf-to-word",
+        name: "PDF to Word/Text Extractor",
+        navLabel: "PDF Extractor",
+        description:
+          "Extract plain text from PDFs in your browser and download it as a Word or TXT file.",
+      },
+      {
+        href: "/calculators/grade-calculator",
+        name: "Grade Goal Calculator",
+        navLabel: "Grade Goal",
+        description:
+          "See the GPA needed in remaining credits or the final exam score required to reach your target.",
+      },
+      {
+        href: "/calculators/meal-planner",
+        name: "Meal Planner & Portion Calculator",
+        navLabel: "Meal Planner",
+        description:
+          "Scale proteins, sides, desserts, and drinks for any gathering based on adults, kids, and leftovers.",
       },
     ],
   },

--- a/src/pages/calculators/event-budget-calculator.astro
+++ b/src/pages/calculators/event-budget-calculator.astro
@@ -1,0 +1,96 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Event Budget Calculator";
+const description = "Plan venue, catering, staffing, and contingency costs for weddings, parties, or corporate events.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/event-budget-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Estimate total event spend by combining fixed venue costs with per-guest food, beverage, and miscellaneous expenses. Add
+      service fees and a contingency buffer to see a realistic total and per-guest target.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="event-budget-form" autocomplete="off">
+      <div class="form-grid columns-3">
+        <div>
+          <label for="event-name">Event name</label>
+          <input id="event-name" name="name" type="text" placeholder="Riverfront wedding" />
+        </div>
+        <div>
+          <label for="event-guests">Guest count</label>
+          <input id="event-guests" name="guests" type="number" min="1" step="1" placeholder="120" required />
+        </div>
+        <div>
+          <label for="event-hours">Event length (hours)</label>
+          <input id="event-hours" name="hours" type="number" min="1" max="24" step="0.5" placeholder="6" />
+        </div>
+      </div>
+
+      <div class="form-grid columns-3" style="margin-top:12px;">
+        <div>
+          <label for="event-venue">Venue & rentals (flat)</label>
+          <input id="event-venue" name="venue" type="number" min="0" step="50" placeholder="4500" />
+        </div>
+        <div>
+          <label for="event-decor">Decor & design (flat)</label>
+          <input id="event-decor" name="decor" type="number" min="0" step="50" placeholder="1500" />
+        </div>
+        <div>
+          <label for="event-entertainment">Entertainment (flat)</label>
+          <input id="event-entertainment" name="entertainment" type="number" min="0" step="50" placeholder="900" />
+        </div>
+      </div>
+
+      <div class="form-grid columns-3" style="margin-top:12px;">
+        <div>
+          <label for="event-food">Food per guest</label>
+          <input id="event-food" name="food" type="number" min="0" step="1" placeholder="65" />
+        </div>
+        <div>
+          <label for="event-drink">Beverage per guest</label>
+          <input id="event-drink" name="drink" type="number" min="0" step="1" placeholder="18" />
+        </div>
+        <div>
+          <label for="event-favors">Extras per guest</label>
+          <input id="event-favors" name="extras" type="number" min="0" step="1" placeholder="5" />
+        </div>
+      </div>
+
+      <div class="form-grid columns-3" style="margin-top:12px;">
+        <div>
+          <label for="event-staff">Staffing & labor (flat)</label>
+          <input id="event-staff" name="staff" type="number" min="0" step="50" placeholder="800" />
+        </div>
+        <div>
+          <label for="event-service">Service charge (%)</label>
+          <input id="event-service" name="service" type="number" min="0" max="30" step="0.5" value="18" />
+        </div>
+        <div>
+          <label for="event-contingency">Contingency buffer (%)</label>
+          <input id="event-contingency" name="contingency" type="number" min="0" max="50" step="1" value="10" />
+        </div>
+      </div>
+
+      <p class="helper" style="margin-top:12px;">
+        Food, beverage, and extras are calculated per guest. Venue, decor, entertainment, and staffing are treated as flat costs.
+      </p>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap; align-items:center;">
+        <button class="btn" type="submit">Build budget</button>
+        <button class="btn" type="reset">Reset</button>
+        <span class="helper" id="event-status">Enter at least a guest count to see the budget.</span>
+      </div>
+    </form>
+  </section>
+
+  <section id="event-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="event-inline-1" />
+  <script defer src="/js/event-budget-calculator.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/flight-time-calculator.astro
+++ b/src/pages/calculators/flight-time-calculator.astro
@@ -1,0 +1,80 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Flight Time Calculator";
+const description = "Estimate nonstop flight duration and arrival time between major airports with time zone awareness.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/flight-time-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Choose departure and arrival airports, set your local departure time, and we'll estimate the nonstop flight duration,
+      arrival time, and time zone difference.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="flight-form" autocomplete="off">
+      <div class="form-grid columns-3">
+        <div>
+          <label for="flight-from">Departure airport</label>
+          <select id="flight-from" name="from" required>
+            <option value="">Select airport</option>
+          </select>
+        </div>
+        <div>
+          <label for="flight-to">Arrival airport</label>
+          <select id="flight-to" name="to" required>
+            <option value="">Select airport</option>
+          </select>
+        </div>
+        <div style="display:flex; align-items:flex-end;">
+          <button class="btn" type="button" id="flight-swap" style="width:100%;">Swap airports</button>
+        </div>
+      </div>
+
+      <div class="form-grid columns-3" style="margin-top:12px;">
+        <div>
+          <label for="flight-date">Departure date</label>
+          <input id="flight-date" name="date" type="date" required />
+        </div>
+        <div>
+          <label for="flight-time">Local departure time</label>
+          <input id="flight-time" name="time" type="time" step="60" required />
+        </div>
+        <div>
+          <label for="flight-speed">Cruise speed (km/h)</label>
+          <input
+            id="flight-speed"
+            name="speed"
+            type="number"
+            min="500"
+            max="1100"
+            step="10"
+            value="900"
+            required
+          />
+        </div>
+      </div>
+
+      <p class="helper" style="margin-top:12px;">
+        We estimate a direct route using great-circle distance and the cruise speed you enter. Adjust the speed up or down to
+        account for prevailing winds or layovers.
+      </p>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap; align-items:center;">
+        <button class="btn" type="submit">Calculate flight</button>
+        <button class="btn" type="reset">Reset</button>
+        <span class="helper" id="flight-status">Pick airports to begin.</span>
+      </div>
+    </form>
+  </section>
+
+  <section id="flight-result" aria-live="polite" style="margin-top:16px;"></section>
+  <section id="flight-airport-notes" class="helper" style="margin-top:12px;"></section>
+
+  <AdSlot id="flight-inline-1" />
+  <script defer src="/js/flight-time-calculator.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/grade-calculator.astro
+++ b/src/pages/calculators/grade-calculator.astro
@@ -1,0 +1,94 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Grade Goal Calculator";
+const description = "See the GPA you need in upcoming credits or the final exam score required to hit your target.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/grade-calculator">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Enter your current GPA, completed credits, and target GPA to learn the average you need in the remaining credits. There's
+      also a final exam planner to show the test score required for a specific course grade.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <h2 style="margin-top:0;">Target cumulative GPA</h2>
+    <form id="gpa-form" autocomplete="off">
+      <div class="form-grid columns-4">
+        <div>
+          <label for="gpa-current">Current GPA</label>
+          <input id="gpa-current" name="current" type="number" min="0" max="4" step="0.01" placeholder="3.2" required />
+        </div>
+        <div>
+          <label for="gpa-credits-complete">Credits completed</label>
+          <input
+            id="gpa-credits-complete"
+            name="completed"
+            type="number"
+            min="0"
+            step="0.5"
+            placeholder="45"
+            required
+          />
+        </div>
+        <div>
+          <label for="gpa-target">Target GPA</label>
+          <input id="gpa-target" name="target" type="number" min="0" max="4" step="0.01" placeholder="3.6" required />
+        </div>
+        <div>
+          <label for="gpa-upcoming">Credits remaining</label>
+          <input id="gpa-upcoming" name="upcoming" type="number" min="1" step="0.5" placeholder="15" required />
+        </div>
+      </div>
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap; align-items:center;">
+        <button class="btn" type="submit">Calculate goal GPA</button>
+        <button class="btn" type="reset">Reset</button>
+        <span class="helper" id="gpa-status">Fill in your current stats to begin.</span>
+      </div>
+    </form>
+  </section>
+
+  <section id="gpa-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <section class="card" style="margin-top:20px;">
+    <h2 style="margin-top:0;">Course final exam planner</h2>
+    <p class="helper">
+      Already tracking a single class? Enter your current average, the exam weight, and the final grade you want to see the
+      test score you need.
+    </p>
+    <form id="final-form" autocomplete="off">
+      <div class="form-grid columns-4">
+        <div>
+          <label for="final-current">Current course average (%)</label>
+          <input id="final-current" name="current" type="number" min="0" max="120" step="0.1" placeholder="87" required />
+        </div>
+        <div>
+          <label for="final-weight">Final exam weight (%)</label>
+          <input id="final-weight" name="weight" type="number" min="1" max="100" step="0.1" placeholder="30" required />
+        </div>
+        <div>
+          <label for="final-target">Target course grade (%)</label>
+          <input id="final-target" name="target" type="number" min="0" max="120" step="0.1" placeholder="90" required />
+        </div>
+        <div>
+          <label for="final-floor">Minimum exam score you can accept (%)</label>
+          <input id="final-floor" name="floor" type="number" min="0" max="120" step="0.1" placeholder="70" />
+        </div>
+      </div>
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap; align-items:center;">
+        <button class="btn" type="submit">Calculate required exam score</button>
+        <button class="btn" type="reset">Reset</button>
+        <span class="helper" id="final-status">Enter course details to see the required score.</span>
+      </div>
+    </form>
+  </section>
+
+  <section id="final-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="grade-inline-1" />
+  <script defer src="/js/grade-calculator.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/meal-planner.astro
+++ b/src/pages/calculators/meal-planner.astro
@@ -1,0 +1,90 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Meal Planner & Portion Calculator";
+const description = "Scale recipes and grocery lists for any gathering based on adult and kid headcount.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/meal-planner">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Enter how many people you're serving and pick a meal style. We'll estimate recommended portions for protein, sides,
+      vegetables, dessert, and drinks—plus the total shopping list with leftovers included.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="meal-form" autocomplete="off">
+      <div class="form-grid columns-4">
+        <div>
+          <label for="meal-adults">Adults</label>
+          <input id="meal-adults" name="adults" type="number" min="0" step="1" value="8" />
+        </div>
+        <div>
+          <label for="meal-kids">Children</label>
+          <input id="meal-kids" name="kids" type="number" min="0" step="1" value="4" />
+        </div>
+        <div>
+          <label for="meal-style">Meal style</label>
+          <select id="meal-style" name="style">
+            <option value="light">Light (brunch, tasting)</option>
+            <option value="standard" selected>Standard dinner</option>
+            <option value="hearty">Hearty (holiday feast)</option>
+          </select>
+        </div>
+        <div>
+          <label for="meal-leftovers">Leftover buffer (%)</label>
+          <input id="meal-leftovers" name="leftovers" type="number" min="0" max="50" step="1" value="10" />
+        </div>
+      </div>
+
+      <fieldset style="margin-top:14px;">
+        <legend>Include courses</legend>
+        <div class="form-grid columns-3">
+          <label class="checkbox">
+            <input type="checkbox" name="course" value="protein" checked />
+            <span>Main protein</span>
+          </label>
+          <label class="checkbox">
+            <input type="checkbox" name="course" value="grains" checked />
+            <span>Starch / grains</span>
+          </label>
+          <label class="checkbox">
+            <input type="checkbox" name="course" value="vegetables" checked />
+            <span>Cooked vegetables</span>
+          </label>
+          <label class="checkbox">
+            <input type="checkbox" name="course" value="salad" checked />
+            <span>Salad</span>
+          </label>
+          <label class="checkbox">
+            <input type="checkbox" name="course" value="dessert" checked />
+            <span>Dessert</span>
+          </label>
+          <label class="checkbox">
+            <input type="checkbox" name="course" value="drinks" checked />
+            <span>Drinks</span>
+          </label>
+        </div>
+      </fieldset>
+
+      <p class="helper" style="margin-top:12px;">
+        Kids count as 0.6 of an adult portion. Adjust the meal style to bump portions up or down and add a leftovers cushion if
+        you want second servings.
+      </p>
+
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap; align-items:center;">
+        <button class="btn" type="submit">Calculate portions</button>
+        <button class="btn" type="reset">Reset</button>
+        <span class="helper" id="meal-status">Enter your headcount to size the meal.</span>
+      </div>
+    </form>
+  </section>
+
+  <section id="meal-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <AdSlot id="meal-inline-1" />
+  <script defer src="/js/meal-planner.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/pdf-to-word.astro
+++ b/src/pages/calculators/pdf-to-word.astro
@@ -1,0 +1,54 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "PDF to Word / Text Extractor";
+const description = "Pull plain text from a PDF and download it as a Word or TXT document.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/pdf-to-word">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Upload a PDF to extract selectable text. We'll do a quick on-device parse—no files ever leave your browser—and let you copy
+      the text or download a simple Word document.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="pdf-form">
+      <label for="pdf-file">Choose a PDF</label>
+      <input id="pdf-file" name="file" type="file" accept="application/pdf" />
+      <p class="helper" style="margin-top:10px;" id="pdf-status">
+        Select a reasonably small text-based PDF (forms and scanned images may not extract cleanly).
+      </p>
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="button" id="pdf-download-word" disabled>Download as Word</button>
+        <button class="btn" type="button" id="pdf-download-text" disabled>Download TXT</button>
+        <button class="btn" type="button" id="pdf-copy" disabled>Copy text</button>
+        <button class="btn" type="reset">Clear</button>
+      </div>
+    </form>
+  </section>
+
+  <section class="card" style="margin-top:16px;">
+    <h2 style="margin-top:0;">Extracted text</h2>
+    <textarea
+      id="pdf-output"
+      rows="12"
+      placeholder="The extracted text will appear here once parsing completes."
+      spellcheck="false"
+    ></textarea>
+    <p class="helper" style="margin-top:10px;">
+      Simple PDFs with embedded text work best. Image-based scans may need OCR before text can be captured.
+    </p>
+    <div class="helper" style="margin-top:12px; display:flex; gap:12px; flex-wrap:wrap;">
+      <span>Characters: <strong id="pdf-char-count">0</strong></span>
+      <span>Words: <strong id="pdf-word-count">0</strong></span>
+      <span>Lines: <strong id="pdf-line-count">0</strong></span>
+    </div>
+  </section>
+
+  <AdSlot id="pdf-inline-1" />
+  <script defer src="/js/pdf-to-word.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/pet-age-converter.astro
+++ b/src/pages/calculators/pet-age-converter.astro
@@ -1,0 +1,64 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Pet Age Converter";
+const description = "Translate dog and cat ages into human years (and back again).";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/pet-age-converter">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Pick a species, choose the conversion direction, and enter an age. We'll apply veterinary growth guidelines to estimate
+      the equivalent age in the other species.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="pet-age-form">
+      <div class="form-grid columns-3">
+        <div>
+          <label for="pet-species">Species</label>
+          <select id="pet-species" name="species">
+            <option value="dog">Dog</option>
+            <option value="cat">Cat</option>
+          </select>
+        </div>
+        <div>
+          <label for="pet-direction">Conversion</label>
+          <select id="pet-direction" name="direction">
+            <option value="pet-to-human">Pet age → Human years</option>
+            <option value="human-to-pet">Human age → Pet years</option>
+          </select>
+        </div>
+        <div>
+          <label for="pet-age">Age</label>
+          <input id="pet-age" name="age" type="number" min="0" step="0.1" placeholder="5" required />
+        </div>
+      </div>
+      <p class="helper" style="margin-top:12px;">
+        Ages are approximate: young pets age quickly in the first two years, then level off. We use a medium-size dog model and
+        an indoor cat model for the conversion.
+      </p>
+      <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap;">
+        <button class="btn" type="submit">Convert age</button>
+        <button class="btn" type="reset">Reset</button>
+      </div>
+    </form>
+  </section>
+
+  <section id="pet-age-result" aria-live="polite" style="margin-top:16px;"></section>
+
+  <section class="card" style="margin-top:18px;">
+    <h2 style="margin-top:0;">Quick reference</h2>
+    <div class="form-grid columns-2" id="pet-reference"></div>
+    <p class="helper" style="margin-top:12px;">
+      Keep in mind that breed size, health, and lifestyle can shift these estimates. Always consult your veterinarian for
+      individualized advice.
+    </p>
+  </section>
+
+  <AdSlot id="pet-inline-1" />
+  <script defer src="/js/pet-age-converter.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/typing-speed-test.astro
+++ b/src/pages/calculators/typing-speed-test.astro
@@ -1,0 +1,101 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Typing Speed Test";
+const description = "Measure your words per minute and accuracy with a timed typing challenge.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/typing-speed-test">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Start the timer, type the prompt as quickly and accurately as you can, and review your words per minute, keystrokes, and
+      accuracy when the test ends.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="typing-settings">
+      <div class="form-grid columns-3">
+        <div>
+          <label for="typing-duration">Test length</label>
+          <select id="typing-duration" name="duration">
+            <option value="60">1 minute</option>
+            <option value="120">2 minutes</option>
+            <option value="180">3 minutes</option>
+          </select>
+        </div>
+        <div>
+          <label for="typing-mode">Prompt style</label>
+          <select id="typing-mode" name="mode">
+            <option value="paragraph">Paragraph</option>
+            <option value="quotes">Famous quotes</option>
+            <option value="numbers">Numbers & symbols</option>
+          </select>
+        </div>
+        <div style="display:flex; align-items:flex-end; gap:10px;">
+          <button class="btn" type="button" id="typing-start" style="flex:1;">Start test</button>
+          <button class="btn" type="button" id="typing-reset" style="flex:1;">Reset</button>
+        </div>
+      </div>
+
+      <p class="helper" id="typing-status" style="margin-top:12px;">Press “Start test” to load a prompt and begin the timer.</p>
+    </form>
+  </section>
+
+  <section class="card" style="margin-top:16px;">
+    <h2 style="margin-top:0;">Typing prompt</h2>
+    <p id="typing-prompt" class="helper" style="min-height:54px;">Prompt text will appear here.</p>
+    <textarea
+      id="typing-input"
+      rows="8"
+      placeholder="The prompt appears above. Click Start when you're ready."
+      disabled
+      spellcheck="false"
+      autocomplete="off"
+      autocorrect="off"
+      autocapitalize="off"
+    ></textarea>
+    <div class="helper" style="margin-top:8px; display:flex; justify-content:space-between; flex-wrap:wrap; gap:8px;">
+      <span>Timer: <strong id="typing-timer">00:00</strong></span>
+      <span>Errors: <strong id="typing-errors">0</strong></span>
+    </div>
+  </section>
+
+  <section class="card" style="margin-top:16px;">
+    <h2 style="margin-top:0;">Live stats</h2>
+    <div class="form-grid columns-3" id="typing-live-stats">
+      <div>
+        <p class="helper">Words per minute</p>
+        <p class="stat" id="typing-wpm">0</p>
+      </div>
+      <div>
+        <p class="helper">Gross WPM</p>
+        <p class="stat" id="typing-gross">0</p>
+      </div>
+      <div>
+        <p class="helper">Accuracy</p>
+        <p class="stat" id="typing-accuracy">100%</p>
+      </div>
+      <div>
+        <p class="helper">Characters typed</p>
+        <p class="stat" id="typing-chars">0</p>
+      </div>
+      <div>
+        <p class="helper">Correct keystrokes</p>
+        <p class="stat" id="typing-correct">0</p>
+      </div>
+      <div>
+        <p class="helper">Mistyped characters</p>
+        <p class="stat" id="typing-missed">0</p>
+      </div>
+    </div>
+    <p class="helper" style="margin-top:12px;">
+      “Gross WPM” measures raw speed using five characters per word. “Words per minute” subtracts errors for a truer score.
+    </p>
+  </section>
+
+  <AdSlot id="typing-inline-1" />
+  <script defer src="/js/typing-speed-test.js"></script>
+</BaseLayout>

--- a/src/pages/calculators/word-counter.astro
+++ b/src/pages/calculators/word-counter.astro
@@ -1,0 +1,77 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import AdSlot from "@/components/AdSlot.astro";
+
+const title = "Word & Character Counter";
+const description = "Count words, characters, sentences, and estimate reading time for any text.";
+---
+
+<BaseLayout {title} {description} pathname="/calculators/word-counter">
+  <section class="hero">
+    <h1>{title}</h1>
+    <p class="helper">
+      Paste or type your writing to instantly see word count, character totals (with and without spaces), sentence count, and a
+      reading time estimate. Set a word target to track your progress.
+    </p>
+  </section>
+
+  <section class="card" style="margin-top:18px;">
+    <form id="word-counter-form">
+      <label for="word-counter-input">Your text</label>
+      <textarea
+        id="word-counter-input"
+        rows="12"
+        placeholder="Paste an article, essay, or brainstorm here to track word count while you write."
+      ></textarea>
+
+      <div class="form-grid columns-3" style="margin-top:14px;">
+        <div>
+          <label for="word-target">Word target (optional)</label>
+          <input id="word-target" name="target" type="number" min="0" step="50" placeholder="1000" />
+        </div>
+        <div>
+          <label for="word-reading-speed">Reading speed (words/min)</label>
+          <input id="word-reading-speed" name="wpm" type="number" min="100" max="400" step="10" value="225" />
+        </div>
+        <div style="display:flex; align-items:flex-end; gap:8px;">
+          <button class="btn" type="button" id="word-copy" style="flex:1;">Copy text</button>
+          <button class="btn" type="reset" style="flex:1;">Clear</button>
+        </div>
+      </div>
+    </form>
+  </section>
+
+  <section class="card" style="margin-top:16px;">
+    <h2 style="margin-top:0;">Counts &amp; estimates</h2>
+    <div class="form-grid columns-3" id="word-counter-stats">
+      <div>
+        <p class="helper">Words</p>
+        <p class="stat" id="word-total">0</p>
+      </div>
+      <div>
+        <p class="helper">Characters (with spaces)</p>
+        <p class="stat" id="char-total">0</p>
+      </div>
+      <div>
+        <p class="helper">Characters (no spaces)</p>
+        <p class="stat" id="char-tight">0</p>
+      </div>
+      <div>
+        <p class="helper">Sentences</p>
+        <p class="stat" id="sentence-total">0</p>
+      </div>
+      <div>
+        <p class="helper">Paragraphs</p>
+        <p class="stat" id="paragraph-total">0</p>
+      </div>
+      <div>
+        <p class="helper">Estimated reading time</p>
+        <p class="stat" id="reading-time">0 min</p>
+      </div>
+    </div>
+    <div id="word-target-progress" class="helper" style="margin-top:12px;"></div>
+  </section>
+
+  <AdSlot id="word-counter-inline-1" />
+  <script defer src="/js/word-counter.js"></script>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- add a flight time calculator with time-zone-aware arrival estimates and airport lookup
- add typing speed, word counter, PDF extractor, grade goal, and pet age tools for productivity and pet owners
- add event budget and meal planner calculators and wire all new tools into the navigation catalogue

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c976fc5d1c8323a5dd220b72672786