### PR TITLE
Add autocomplete airport comboboxes to flight time calculator

### DIFF
--- a/src/pages/calculators/flight-time-calculator.astro
+++ b/src/pages/calculators/flight-time-calculator.astro
@@ -19,16 +19,50 @@ const description = "Estimate nonstop flight duration and arrival time between m
     <form id="flight-form" autocomplete="off">
       <div class="form-grid columns-3">
         <div>
-          <label for="flight-from">Departure airport</label>
-          <select id="flight-from" name="from" required>
-            <option value="">Select airport</option>
-          </select>
+          <label for="flight-from-search">Departure airport</label>
+          <div class="airport-combobox">
+            <input
+              id="flight-from-search"
+              type="text"
+              inputmode="search"
+              autocomplete="off"
+              placeholder="Search airports"
+              role="combobox"
+              aria-autocomplete="list"
+              aria-expanded="false"
+              aria-controls="flight-from-results"
+              spellcheck="false"
+            />
+            <input id="flight-from" name="from" type="hidden" />
+            <div
+              id="flight-from-results"
+              class="airport-combobox-list"
+              role="listbox"
+            ></div>
+          </div>
         </div>
         <div>
-          <label for="flight-to">Arrival airport</label>
-          <select id="flight-to" name="to" required>
-            <option value="">Select airport</option>
-          </select>
+          <label for="flight-to-search">Arrival airport</label>
+          <div class="airport-combobox">
+            <input
+              id="flight-to-search"
+              type="text"
+              inputmode="search"
+              autocomplete="off"
+              placeholder="Search airports"
+              role="combobox"
+              aria-autocomplete="list"
+              aria-expanded="false"
+              aria-controls="flight-to-results"
+              spellcheck="false"
+            />
+            <input id="flight-to" name="to" type="hidden" />
+            <div
+              id="flight-to-results"
+              class="airport-combobox-list"
+              role="listbox"
+            ></div>
+          </div>
         </div>
         <div style="display:flex; align-items:flex-end;">
           <button class="btn" type="button" id="flight-swap" style="width:100%;">Swap airports</button>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -323,6 +323,62 @@ select {
   background: #0d1325;
   color: var(--text);
 }
+
+.airport-combobox {
+  position: relative;
+}
+
+.airport-combobox-list {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  max-height: 260px;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--panel-2);
+  box-shadow: var(--shadow);
+  display: none;
+  z-index: 30;
+  padding: 6px 0;
+}
+
+.airport-combobox-list.open {
+  display: block;
+}
+
+.airport-combobox-option {
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+}
+
+.airport-combobox-option + .airport-combobox-option {
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.airport-combobox-option.is-active,
+.airport-combobox-option:hover {
+  background: rgba(78, 140, 255, 0.18);
+}
+
+.airport-combobox-title {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.airport-combobox-meta {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.airport-combobox-empty {
+  padding: 10px 12px;
+  color: var(--muted);
+}
 textarea {
   width: 100%;
   min-height: 120px;


### PR DESCRIPTION
## Summary
- replace the airport dropdowns with searchable combobox inputs to avoid long scrolling lists
- add client-side filtering logic so airport suggestions refine as the user types and keep selections in sync
- style the new combobox suggestion list to match the site and keep helper messaging updated

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c998208bf8832394cd186c70d216fa