### PR TITLE
Rebrand to Click Calculations and streamline mobile navigation

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,7 +3,7 @@ import "@/styles/global.css";
 import { calculatorCategories } from "@/lib/calculatorData";
 
 const {
-  title = "Calculator Hub",
+  title = "Click Calculations",
   description = "Free date & holiday calculators",
   pathname = "/",
 } = Astro.props;
@@ -18,6 +18,9 @@ const url = new URL(pathname, Astro.site ?? "http://localhost:4321");
     <title>{title}</title>
     <meta name="description" content={description} />
     <link rel="icon" href="/favicon.svg" />
+    <script is:inline>
+      document.documentElement.classList.add("js");
+    </script>
 
     <!-- Social -->
     <meta property="og:title" content={title} />
@@ -28,8 +31,16 @@ const url = new URL(pathname, Astro.site ?? "http://localhost:4321");
   <body>
     <header class="site-header">
       <div class="container header-inner">
-        <a class="brand" href="/">CalcNest</a>
-        <nav class="nav" aria-label="Main">
+        <a class="brand" href="/">Click Calculations</a>
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="site-nav">
+          <span class="menu-icon" aria-hidden="true">
+            <span></span>
+            <span></span>
+            <span></span>
+          </span>
+          Menu
+        </button>
+        <nav id="site-nav" class="nav" aria-label="Main" data-visible="false">
           <ul class="nav-list">
             {calculatorCategories.map((category) => (
               <li>
@@ -56,9 +67,57 @@ const url = new URL(pathname, Astro.site ?? "http://localhost:4321");
 
     <footer class="site-footer">
       <div class="container footer-inner">
-        <p>© {new Date().getFullYear()} CalcNest</p>
+        <p>© {new Date().getFullYear()} Click Calculations</p>
         <p><a href="/privacy">Privacy</a> · <a href="/terms">Terms</a></p>
       </div>
     </footer>
+    <script is:inline>
+      const toggle = document.querySelector(".menu-toggle");
+      const nav = document.getElementById("site-nav");
+      const mediaQuery = window.matchMedia("(min-width: 721px)");
+
+      const setStateForViewport = () => {
+        if (!nav || !toggle) return;
+        if (mediaQuery.matches) {
+          nav.setAttribute("data-visible", "true");
+          toggle.setAttribute("aria-expanded", "false");
+        } else {
+          nav.setAttribute("data-visible", "false");
+          toggle.setAttribute("aria-expanded", "false");
+        }
+      };
+
+      toggle?.addEventListener("click", () => {
+        if (!nav || !toggle) return;
+        const isOpen = nav.getAttribute("data-visible") === "true";
+        const next = (!isOpen).toString();
+        nav.setAttribute("data-visible", next);
+        toggle.setAttribute("aria-expanded", next);
+      });
+
+      nav?.addEventListener("click", (event) => {
+        if (!nav || !toggle) return;
+        if (mediaQuery.matches) return;
+        const target = event.target;
+        if (target instanceof HTMLAnchorElement) {
+          nav.setAttribute("data-visible", "false");
+          toggle.setAttribute("aria-expanded", "false");
+        }
+      });
+
+      document.addEventListener("keydown", (event) => {
+        if (!nav || !toggle) return;
+        if (event.key !== "Escape") return;
+        if (mediaQuery.matches) return;
+        if (nav.getAttribute("data-visible") === "true") {
+          nav.setAttribute("data-visible", "false");
+          toggle.setAttribute("aria-expanded", "false");
+          toggle.focus();
+        }
+      });
+
+      setStateForViewport();
+      mediaQuery.addEventListener("change", setStateForViewport);
+    </script>
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,11 +4,11 @@ import { calculatorCategories } from "@/lib/calculatorData";
 ---
 
 <BaseLayout
-  title="CalcNest – Date, Money, and Planning Calculators"
+  title="Click Calculations – Date, Money, and Planning Calculators"
   description="Plan schedules and finances with countdowns, loan tools, currency converters, and more."
 >
   <section class="hero">
-    <h1>Everyday Calculators</h1>
+    <h1>Click Calculations</h1>
     <p>Plan timelines, budgets, and goals in one place. All tools run instantly in your browser—no sign-up required.</p>
   </section>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -69,11 +69,46 @@ a:hover {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
+  position: relative;
 }
 .brand {
   font-weight: 800;
   font-size: 20px;
   letter-spacing: 0.2px;
+}
+.menu-toggle {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--panel-2);
+  color: var(--text);
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+.menu-toggle:hover,
+.menu-toggle:focus-visible {
+  border-color: rgba(78, 140, 255, 0.25);
+  background: rgba(78, 140, 255, 0.12);
+  outline: none;
+}
+.menu-icon {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.menu-icon span {
+  display: block;
+  width: 18px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
 }
 .nav {
   margin-left: auto;
@@ -231,6 +266,72 @@ a:hover {
     border-radius: 12px;
     background: var(--panel);
     gap: 8px;
+  }
+}
+
+@media (max-width: 720px) {
+  html.js .header-inner {
+    flex-wrap: nowrap;
+    align-items: center;
+  }
+
+  html.js .menu-toggle {
+    display: inline-flex;
+  }
+
+  html.js .nav {
+    width: auto;
+    position: absolute;
+    top: calc(100% + 12px);
+    right: 24px;
+    left: 24px;
+    display: flex;
+    flex-direction: column;
+    padding: 16px;
+    border-radius: 16px;
+    border: 1px solid var(--border);
+    background: var(--panel-2);
+    box-shadow: var(--shadow);
+    gap: 12px;
+    max-height: calc(100vh - 120px);
+    overflow-y: auto;
+    z-index: 30;
+  }
+
+  html.js .nav[data-visible="false"] {
+    display: none;
+  }
+
+  html.js .nav[data-visible="true"] {
+    display: flex;
+  }
+
+  html.js .nav-list {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  html.js .nav-category {
+    width: 100%;
+  }
+
+  html.js .nav-category > summary {
+    width: 100%;
+    padding: 10px 14px;
+    border-radius: 12px;
+    border: 1px solid var(--border);
+    background: var(--panel);
+  }
+
+  html.js .nav-panel {
+    position: static;
+    margin-top: 8px;
+    padding: 10px;
+    border-radius: 12px;
+    background: var(--panel-2);
+    gap: 6px;
   }
 }
 


### PR DESCRIPTION
## Summary
- rename site branding to Click Calculations across the shared layout and homepage hero
- add a mobile menu toggle with supporting script so the categorized navigation collapses until opened
- refresh global styles for the compact menu experience while keeping desktop navigation unchanged

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c9a0eaffc48323ae0c05f1131382b6