### PR TITLE
Add reusable input instructions across calculators

### DIFF
--- a/src/components/InstructionList.astro
+++ b/src/components/InstructionList.astro
@@ -1,0 +1,18 @@
+---
+const { heading = "How to use this tool", items = [], footer } = Astro.props;
+---
+
+{items.length > 0 && (
+  <section class="card info-card instructions-card" aria-label="Input instructions">
+    <h2>{heading}</h2>
+    <ul class="instructions-list">
+      {items.map((item) => (
+        <li>
+          <span class="instructions-term">{item.label}</span>
+          <span class="instructions-detail">{item.description}</span>
+        </li>
+      ))}
+    </ul>
+    {footer && <p class="helper">{footer}</p>}
+  </section>
+)}

--- a/src/pages/calculators/age-calculator.astro
+++ b/src/pages/calculators/age-calculator.astro
@@ -1,9 +1,19 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Age Calculator";
 const description = "Enter a birthdate and instantly get age in years, months, and days.";
+const instructions = [
+  {
+    label: "Birthdate",
+    description:
+      "Enter the date of birth you want to measure. Type it as YYYY-MM-DD or MM/DD/YYYY, or open the calendar picker to choose a date.",
+  },
+];
+const instructionsFooter =
+  "Select Calculate Age to break the result down into years, months, and days. Use Clear to wipe the form and start again.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/age-calculator">
@@ -11,6 +21,8 @@ const description = "Enter a birthdate and instantly get age in years, months, a
     <h1>{title}</h1>
     <p class="helper">Type your birthdate. We'll break down your age by years, months, and days.</p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="age-form">

--- a/src/pages/calculators/anniversary-countdown.astro
+++ b/src/pages/calculators/anniversary-countdown.astro
@@ -1,8 +1,18 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 const title = "Anniversary Countdown";
 const description = "Input a special date and see upcoming anniversary milestones.";
+const instructions = [
+  {
+    label: "Special Date",
+    description:
+      "Pick the original date you want to celebrate. Type it in manually or use the calendar button to select the exact day.",
+  },
+];
+const instructionsFooter =
+  "Choose Show Anniversaries to list future milestones and remaining days. Use Clear to remove the date and start again.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/anniversary-countdown">
@@ -10,6 +20,8 @@ const description = "Input a special date and see upcoming anniversary milestone
     <h1>{title}</h1>
     <p class="helper">Enter a meaningful date to preview the next anniversaries and days remaining.</p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="anniversary-form">

--- a/src/pages/calculators/bmi-calculator.astro
+++ b/src/pages/calculators/bmi-calculator.astro
@@ -1,9 +1,27 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "BMI Calculator";
 const description = "Check your body mass index and see a healthy weight range for your height.";
+const instructions = [
+  {
+    label: "Units",
+    description:
+      "Choose Metric for centimeters and kilograms or Imperial for inches and pounds. Height and weight labels update instantly.",
+  },
+  {
+    label: "Height",
+    description: "Enter your height using the units you selected. Decimals are welcome for half units.",
+  },
+  {
+    label: "Weight",
+    description: "Enter your current body weight in the matching units. Include decimals if needed for accuracy.",
+  },
+];
+const instructionsFooter =
+  "Press Calculate BMI to see your body mass index and the healthy weight range for that height. Reset clears the form.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/bmi-calculator">
@@ -14,6 +32,8 @@ const description = "Check your body mass index and see a healthy weight range f
       BMI is a starting point—muscle mass and body composition matter too.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="bmi-form">

--- a/src/pages/calculators/bmr-calorie-calculator.astro
+++ b/src/pages/calculators/bmr-calorie-calculator.astro
@@ -1,10 +1,40 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "BMR & Calorie Needs Calculator";
 const description =
   "Estimate your basal metabolic rate and daily calorie targets using the Mifflin-St Jeor equation.";
+const instructions = [
+  {
+    label: "Sex",
+    description: "Choose the biological sex that matches the equation you want to use for estimating BMR.",
+  },
+  {
+    label: "Age",
+    description: "Enter your age in years. The Mifflin-St Jeor formula is validated for adults.",
+  },
+  {
+    label: "Units",
+    description: "Select Metric (cm, kg) or Imperial (in, lb). Height and weight placeholders adjust to match.",
+  },
+  {
+    label: "Height",
+    description: "Enter your height in the units you selected. Decimals let you capture partial centimeters or inches.",
+  },
+  {
+    label: "Weight",
+    description: "Enter your current body weight in the same measurement system. Include decimals if helpful.",
+  },
+  {
+    label: "Activity level",
+    description:
+      "Pick the option that best matches your weekly exercise. It sets the multiplier for maintenance calories.",
+  },
+];
+const instructionsFooter =
+  "Hit Estimate calories to see BMR plus maintenance, cut, and surplus targets. Reset clears everything so you can start fresh.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/bmr-calorie-calculator">
@@ -15,6 +45,8 @@ const description =
       The calculator uses the clinically trusted Mifflin-St Jeor formula for BMR.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="bmr-form">

--- a/src/pages/calculators/body-fat-estimator.astro
+++ b/src/pages/calculators/body-fat-estimator.astro
@@ -1,10 +1,43 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Body Fat Percentage Estimator";
 const description =
   "Approximate your body fat percentage and lean mass using the U.S. Navy tape-measure method.";
+const instructions = [
+  {
+    label: "Sex",
+    description: "Choose male or female so the correct Navy equation is applied.",
+  },
+  {
+    label: "Units",
+    description: "Pick Metric (cm, kg) or Imperial (in, lb). Input prompts update to match your choice.",
+  },
+  {
+    label: "Weight",
+    description: "Enter your scale weight using the selected units.",
+  },
+  {
+    label: "Height",
+    description: "Measure your height and enter it in centimeters or inches.",
+  },
+  {
+    label: "Neck",
+    description: "Wrap the tape just below the Adam's apple and record the circumference.",
+  },
+  {
+    label: "Waist (navel)",
+    description: "Measure around your natural waistline at the level of the navel while standing relaxed.",
+  },
+  {
+    label: "Hip",
+    description: "Only needed for the female formula. Measure the widest point around the glutes; leave blank if you're using the male equation.",
+  },
+];
+const instructionsFooter =
+  "Click Estimate body fat to calculate percentage and lean mass from your measurements. Reset clears the form.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/body-fat-estimator">
@@ -15,6 +48,8 @@ const description =
       percentage and lean mass.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="body-fat-form">

--- a/src/pages/calculators/car-loan-affordability-calculator.astro
+++ b/src/pages/calculators/car-loan-affordability-calculator.astro
@@ -1,9 +1,46 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Car Loan Affordability Calculator";
 const description = "Estimate a comfortable vehicle price using income, existing debt, and loan terms.";
+const instructions = [
+  {
+    label: "Gross annual income",
+    description: "Enter your household income before taxes. The calculator uses it to determine an affordable payment.",
+  },
+  {
+    label: "Current monthly debt payments",
+    description: "List the total of other required monthly debts—student loans, credit cards, etc.—to protect your debt-to-income ratio.",
+  },
+  {
+    label: "Loan term",
+    description: "Pick how many months you plan to finance the vehicle. Longer terms lower the payment but cost more in interest.",
+  },
+  {
+    label: "Loan APR (%)",
+    description: "Enter the expected annual percentage rate from your lender. Leave the default if you're estimating.",
+  },
+  {
+    label: "Cash down payment",
+    description: "Add the cash you can put down at purchase. It reduces the amount you need to finance.",
+  },
+  {
+    label: "Trade-in value",
+    description: "If you're trading in a vehicle, enter the equity you'll apply after paying off any existing loan.",
+  },
+  {
+    label: "Target share of monthly income",
+    description: "Set the percentage of gross income you want to allocate toward the new car payment.",
+  },
+  {
+    label: "Sales tax rate",
+    description: "Enter your local auto sales tax percentage so the estimated vehicle price includes taxes.",
+  },
+];
+const instructionsFooter =
+  "Click Estimate car budget to see the recommended payment, maximum loan amount, and target vehicle price. Reset clears the form.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/car-loan-affordability-calculator">
@@ -14,6 +51,8 @@ const description = "Estimate a comfortable vehicle price using income, existing
       debt-to-income ratio on target. We'll convert that into an estimated car price based on your down payment.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="car-form">

--- a/src/pages/calculators/clothing-size-converter.astro
+++ b/src/pages/calculators/clothing-size-converter.astro
@@ -1,9 +1,26 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Clothing Size Converter";
 const description = "Find approximate international equivalents for men's and women's clothing sizes.";
+const instructions = [
+  {
+    label: "Sizing chart",
+    description: "Choose whether you want women's or men's apparel conversions. It loads the matching size chart.",
+  },
+  {
+    label: "I know my size in",
+    description: "Select the sizing system you already have—International, US, UK, or EU.",
+  },
+  {
+    label: "Size",
+    description: "Pick your current size from the drop-down. The tool will show the best-matching sizes in the other systems.",
+  },
+];
+const instructionsFooter =
+  "Press Convert to see equivalent sizes across the remaining regions. Reset switches everything back to the defaults.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/clothing-size-converter">
@@ -14,6 +31,8 @@ const description = "Find approximate international equivalents for men's and wo
       regions. Use this as a starting point when shopping abroad.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="clothing-form">

--- a/src/pages/calculators/compound-interest-calculator.astro
+++ b/src/pages/calculators/compound-interest-calculator.astro
@@ -1,9 +1,38 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Compound Interest Calculator";
 const description = "Project how investments grow with compound interest and monthly contributions.";
+const instructions = [
+  {
+    label: "Starting balance",
+    description: "Enter your current investment balance or initial deposit.",
+  },
+  {
+    label: "Monthly contribution",
+    description: "Add the amount you plan to contribute each month. Leave zero if you are not adding more money.",
+  },
+  {
+    label: "Annual return (%)",
+    description: "Enter your expected average yearly rate of return before fees.",
+  },
+  {
+    label: "Years invested",
+    description: "Set how long you will keep the money invested.",
+  },
+  {
+    label: "Compounding frequency",
+    description: "Choose how often interest is compounded—annually, quarterly, monthly, or daily.",
+  },
+  {
+    label: "Annual contribution increase (%)",
+    description: "If you plan to raise contributions each year, enter the yearly percentage bump. Leave at 0% to keep payments flat.",
+  },
+];
+const instructionsFooter =
+  "Click Calculate growth to forecast your ending balance, total contributions, and interest earned. Reset clears your inputs.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/compound-interest-calculator">
@@ -11,6 +40,8 @@ const description = "Project how investments grow with compound interest and mon
     <h1>{title}</h1>
     <p class="helper">See how your starting balance and recurring deposits compound over time. Adjust the compounding frequency to match your account.</p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="compound-form">

--- a/src/pages/calculators/cooking-measurement-converter.astro
+++ b/src/pages/calculators/cooking-measurement-converter.astro
@@ -1,9 +1,26 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Cooking Measurement Converter";
 const description = "Swap between cups, grams, ounces, tablespoons, and more with a kitchen-friendly reference.";
+const instructions = [
+  {
+    label: "Amount",
+    description: "Enter the quantity you want to convert. Fractions and decimals both work.",
+  },
+  {
+    label: "From",
+    description: "Choose the unit you currently have—cups, grams, teaspoons, etc.",
+  },
+  {
+    label: "To",
+    description: "Select the unit you need the amount converted into.",
+  },
+];
+const instructionsFooter =
+  "Press Convert to see the exact conversion plus a handy table of all other units. Reset restores the defaults.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/cooking-measurement-converter">
@@ -14,6 +31,8 @@ const description = "Swap between cups, grams, ounces, tablespoons, and more wit
       kitchen math.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="cooking-form">

--- a/src/pages/calculators/credit-card-interest-calculator.astro
+++ b/src/pages/calculators/credit-card-interest-calculator.astro
@@ -1,9 +1,38 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Credit Card Interest Calculator";
 const description = "Project the cost of revolving a credit card balance and see how extra payments shorten payoff time.";
+const instructions = [
+  {
+    label: "Current balance",
+    description: "Enter the credit card balance you are carrying right now.",
+  },
+  {
+    label: "APR (%)",
+    description: "Input the card's annual percentage rate. You'll find it on your statement.",
+  },
+  {
+    label: "Monthly payment",
+    description: "Type the amount you plan to pay each month. Use at least the required minimum.",
+  },
+  {
+    label: "Additional monthly payment",
+    description: "Optionally add extra money you can commit on top of your planned payment.",
+  },
+  {
+    label: "New charges per month",
+    description: "If you expect to keep using the card, enter the average new spending added each month.",
+  },
+  {
+    label: "Minimum payment floor",
+    description: "Some cards have a fixed dollar minimum even when your percentage payment is smaller. Enter that amount here.",
+  },
+];
+const instructionsFooter =
+  "Press Estimate interest to view payoff time, total interest, and how extra payments change the schedule. Reset clears the inputs.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/credit-card-interest-calculator">
@@ -14,6 +43,8 @@ const description = "Project the cost of revolving a credit card balance and see
       extra payment to compare how quickly the balance disappears.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="credit-form">

--- a/src/pages/calculators/currency-converter.astro
+++ b/src/pages/calculators/currency-converter.astro
@@ -1,9 +1,26 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Currency Converter";
 const description = "Convert between world currencies with live exchange rates.";
+const instructions = [
+  {
+    label: "Amount",
+    description: "Enter how much money you have in the source currency.",
+  },
+  {
+    label: "From",
+    description: "Choose the currency you are converting from.",
+  },
+  {
+    label: "To",
+    description: "Select the currency you want to convert into.",
+  },
+];
+const instructionsFooter =
+  "Hit Convert to pull the current exchange rate and display the converted total. Use Swap to flip the currencies.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/currency-converter">
@@ -11,6 +28,8 @@ const description = "Convert between world currencies with live exchange rates."
     <h1>{title}</h1>
     <p class="helper">Pick two currencies and enter an amount. We'll fetch the latest rates (with an offline fallback) and show the converted value instantly.</p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="currency-form">

--- a/src/pages/calculators/days-from-date.astro
+++ b/src/pages/calculators/days-from-date.astro
@@ -1,8 +1,23 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 const title = "Days From (or Until) a Date";
 const description = "Calculate days between today and a specific date, or between two dates.";
+const instructions = [
+  {
+    label: "Date",
+    description:
+      "Enter the main date you care about. Type it in or use the calendar picker to choose an exact day.",
+  },
+  {
+    label: "Compare To",
+    description:
+      "Optional. Leave blank to compare against today, or pick another date to see the difference between two specific days.",
+  },
+];
+const instructionsFooter =
+  "Select Calculate to see how many days separate the dates and whether the event is in the past or future. Clear resets the form.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/days-from-date">
@@ -10,6 +25,8 @@ const description = "Calculate days between today and a specific date, or betwee
     <h1>{title}</h1>
     <p class="helper">Enter a date, and optionally a comparison date. We’ll tell you how many days separate them.</p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="dfd-form">

--- a/src/pages/calculators/days-until-birthday.astro
+++ b/src/pages/calculators/days-until-birthday.astro
@@ -1,8 +1,21 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 const title = "Days Until Your Birthday";
 const description = "Countdown to your next birthday with leap-year handling.";
+const instructions = [
+  {
+    label: "Month",
+    description: "Select the month of your birthday.",
+  },
+  {
+    label: "Day",
+    description: "Enter the day of the month. We'll automatically account for shorter months and leap years.",
+  },
+];
+const instructionsFooter =
+  "Choose Calculate to see how many days remain until your next birthday. Clear resets the dropdown and number field.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/days-until-birthday">
@@ -10,6 +23,8 @@ const description = "Countdown to your next birthday with leap-year handling.";
     <h1>{title}</h1>
     <p class="helper">Pick your month and day. We’ll handle leap years automatically.</p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="bday-form">

--- a/src/pages/calculators/debt-payoff-calculator.astro
+++ b/src/pages/calculators/debt-payoff-calculator.astro
@@ -1,9 +1,27 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Debt Payoff Calculator";
 const description = "Compare the snowball vs. avalanche strategy with payoff timelines and interest totals.";
+const instructions = [
+  {
+    label: "Debt list",
+    description:
+      "For each balance, enter a name (optional), the current balance, APR, and minimum payment. Use Add another debt to include every loan or card you plan to pay off.",
+  },
+  {
+    label: "Extra monthly payment toward debt",
+    description: "If you can pay more than the required minimums, enter the extra cash available each month.",
+  },
+  {
+    label: "Starting month (optional)",
+    description: "Choose the month you expect to begin the payoff plan. Leave blank to start from the current month.",
+  },
+];
+const instructionsFooter =
+  "Select Compare snowball & avalanche to see payoff dates, total interest, and which strategy clears debts first. Reset clears all debts and settings.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/debt-payoff-calculator">
@@ -14,6 +32,8 @@ const description = "Compare the snowball vs. avalanche strategy with payoff tim
       (smallest balance first) and avalanche (highest interest rate first) side by side.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="debt-form">

--- a/src/pages/calculators/event-budget-calculator.astro
+++ b/src/pages/calculators/event-budget-calculator.astro
@@ -1,9 +1,42 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Event Budget Calculator";
 const description = "Plan venue, catering, staffing, and contingency costs for weddings, parties, or corporate events.";
+const instructions = [
+  {
+    label: "Event name",
+    description: "Optional label to identify the plan in your download or printout.",
+  },
+  {
+    label: "Guest count",
+    description: "Enter the number of attendees you expect. It drives all per-guest calculations.",
+  },
+  {
+    label: "Event length (hours)",
+    description: "Add the total hours the event runs to help estimate staffing and overtime needs.",
+  },
+  {
+    label: "Venue, decor, entertainment, staffing",
+    description: "Input fixed costs you pay regardless of guests—for space rental, design, performers, and labor.",
+  },
+  {
+    label: "Food, beverage, extras per guest",
+    description: "Enter per-person costs for catering, drinks, favors, or swag so the tool scales them by guest count.",
+  },
+  {
+    label: "Service charge (%)",
+    description: "If vendors add a service fee, enter the percentage so it's applied to the subtotal.",
+  },
+  {
+    label: "Contingency buffer (%)",
+    description: "Add a cushion for surprises. We'll tack this percentage onto the total budget.",
+  },
+];
+const instructionsFooter =
+  "Press Build budget to see the total cost, per-guest target, and a detailed breakdown. Reset clears all numbers.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/event-budget-calculator">
@@ -14,6 +47,8 @@ const description = "Plan venue, catering, staffing, and contingency costs for w
       service fees and a contingency buffer to see a realistic total and per-guest target.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="event-budget-form" autocomplete="off">

--- a/src/pages/calculators/flight-time-calculator.astro
+++ b/src/pages/calculators/flight-time-calculator.astro
@@ -1,9 +1,35 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Flight Time Calculator";
 const description = "Estimate nonstop flight duration and arrival time between major airports with time zone awareness.";
+const instructions = [
+  {
+    label: "Departure airport",
+    description:
+      "Start typing a city or airport code, then choose the correct airport from the suggestions. This sets the origin time zone.",
+  },
+  {
+    label: "Arrival airport",
+    description: "Search for and select your destination airport. Use Swap to flip the two if needed.",
+  },
+  {
+    label: "Departure date",
+    description: "Pick the calendar date you leave.",
+  },
+  {
+    label: "Local departure time",
+    description: "Enter the local time your flight takes off at the origin airport.",
+  },
+  {
+    label: "Cruise speed (km/h)",
+    description: "Adjust the assumed cruising speed. Increase or decrease it to account for aircraft type or winds.",
+  },
+];
+const instructionsFooter =
+  "Choose Calculate flight to estimate duration, arrival time, and time difference. Reset clears your selections.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/flight-time-calculator">
@@ -14,6 +40,8 @@ const description = "Estimate nonstop flight duration and arrival time between m
       arrival time, and time zone difference.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="flight-form" autocomplete="off">

--- a/src/pages/calculators/freelancer-hourly-rate-calculator.astro
+++ b/src/pages/calculators/freelancer-hourly-rate-calculator.astro
@@ -1,9 +1,46 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Freelancer Hourly Rate Calculator";
 const description = "Back into a sustainable freelance rate using income goals, billable hours, and overhead.";
+const instructions = [
+  {
+    label: "Desired annual take-home pay",
+    description: "Enter the net income you want to pay yourself each year after covering business expenses.",
+  },
+  {
+    label: "Estimated annual business expenses",
+    description: "Add recurring costs like software, insurance, rent, and equipment.",
+  },
+  {
+    label: "Billable hours per week",
+    description: "Estimate how many hours you can actually invoice each week, not total working hours.",
+  },
+  {
+    label: "Unpaid weeks off each year",
+    description: "Account for holidays, vacations, or downtime when you will not bill clients.",
+  },
+  {
+    label: "Profit cushion (%)",
+    description: "Add a markup to cover admin time and unexpected scope. Increase it if you want more buffer.",
+  },
+  {
+    label: "Self-employment tax & benefits reserve (%)",
+    description: "Set aside a percentage of revenue for taxes, health insurance, and retirement savings.",
+  },
+  {
+    label: "Estimated project hours (optional)",
+    description: "If quoting a specific job, enter the total hours you expect the project to take.",
+  },
+  {
+    label: "Project expenses (optional)",
+    description: "Add pass-through costs for subcontractors, travel, or materials tied to that project.",
+  },
+];
+const instructionsFooter =
+  "Press Calculate rate to see your break-even hourly rate, suggested markup, and a project quote if provided. Reset clears everything.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/freelancer-hourly-rate-calculator">
@@ -14,6 +51,8 @@ const description = "Back into a sustainable freelance rate using income goals, 
       you can bill. Add a project scope to translate the rate into a suggested quote.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="freelance-form">

--- a/src/pages/calculators/fuel-economy-converter.astro
+++ b/src/pages/calculators/fuel-economy-converter.astro
@@ -1,9 +1,21 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Fuel Economy Converter";
 const description = "Translate MPG to liters per 100 km (and back) for easy vehicle comparisons.";
+const instructions = [
+  {
+    label: "Conversion direction",
+    description: "Choose whether you are converting an MPG rating to liters per 100 km or the other way around.",
+  },
+  {
+    label: "Value",
+    description: "Enter the fuel economy number you already know. Use decimals for precise ratings.",
+  },
+];
+const instructionsFooter = "Select Convert to see the converted efficiency. Reset clears the selection and value.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/fuel-economy-converter">
@@ -14,6 +26,8 @@ const description = "Translate MPG to liters per 100 km (and back) for easy vehi
       235.21458 factor.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="fuel-form">

--- a/src/pages/calculators/grade-calculator.astro
+++ b/src/pages/calculators/grade-calculator.astro
@@ -1,9 +1,46 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Grade Goal Calculator";
 const description = "See the GPA you need in upcoming credits or the final exam score required to hit your target.";
+const instructions = [
+  {
+    label: "Current GPA",
+    description: "Enter your cumulative GPA as of now.",
+  },
+  {
+    label: "Credits completed",
+    description: "Provide the number of credits already finished so we can weight your existing GPA.",
+  },
+  {
+    label: "Target GPA",
+    description: "Type the cumulative GPA you hope to reach.",
+  },
+  {
+    label: "Credits remaining",
+    description: "Enter how many additional credits you'll take. The tool solves for the average GPA needed in them.",
+  },
+  {
+    label: "Current course average (%)",
+    description: "If planning for a single class, enter your present grade before the final exam.",
+  },
+  {
+    label: "Final exam weight (%)",
+    description: "Enter what percent of the course grade the final exam counts for.",
+  },
+  {
+    label: "Target course grade (%)",
+    description: "State the final course average you want.",
+  },
+  {
+    label: "Minimum exam score you can accept (%)",
+    description: "Optional. Add the lowest exam score you are comfortable with to see whether it's enough.",
+  },
+];
+const instructionsFooter =
+  "Use Calculate goal GPA to find the average needed in remaining credits, and Calculate required exam score to plan for a single course. Reset clears each section.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/grade-calculator">
@@ -14,6 +51,8 @@ const description = "See the GPA you need in upcoming credits or the final exam 
       also a final exam planner to show the test score required for a specific course grade.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <h2 style="margin-top:0;">Target cumulative GPA</h2>

--- a/src/pages/calculators/hex-rgb-color-converter.astro
+++ b/src/pages/calculators/hex-rgb-color-converter.astro
@@ -1,9 +1,21 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Hex ↔ RGB Color Converter";
 const description = "Convert brand colors between hexadecimal and RGB values with a live preview.";
+const instructions = [
+  {
+    label: "Hex color",
+    description: "Type a color in #RGB or #RRGGBB format. We'll normalize it and show the RGB values.",
+  },
+  {
+    label: "RGB color",
+    description: "Enter three numbers between 0 and 255 separated by commas or spaces to convert back to hex.",
+  },
+];
+const instructionsFooter = "Submit the form to sync both color formats and preview the swatch. Reset clears both fields.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/hex-rgb-color-converter">
@@ -14,6 +26,8 @@ const description = "Convert brand colors between hexadecimal and RGB values wit
       other format while previewing the swatch.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="color-form">

--- a/src/pages/calculators/holiday-countdown.astro
+++ b/src/pages/calculators/holiday-countdown.astro
@@ -1,8 +1,16 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 const title = "Holiday Countdown (US)";
 const description = "See days until major U.S. holidays.";
+const instructions = [
+  {
+    label: "Holiday",
+    description: "Choose the holiday you want to track from the dropdown list.",
+  },
+];
+const instructionsFooter = "Press Show Countdown to display the date and remaining days.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/holiday-countdown">
@@ -10,6 +18,8 @@ const description = "See days until major U.S. holidays.";
     <h1>{title}</h1>
     <p class="helper">Pick a holiday to see the exact date and days remaining.</p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="h-form">

--- a/src/pages/calculators/inflation-calculator.astro
+++ b/src/pages/calculators/inflation-calculator.astro
@@ -1,9 +1,25 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Inflation Calculator";
 const description = "Compare purchasing power across years using U.S. CPI data.";
+const instructions = [
+  {
+    label: "Amount",
+    description: "Enter the dollar amount you want to adjust.",
+  },
+  {
+    label: "Start year",
+    description: "Choose the year you want to measure from.",
+  },
+  {
+    label: "End year",
+    description: "Select the comparison year to see what the original amount is worth after inflation.",
+  },
+];
+const instructionsFooter = "Click Adjust for inflation to compare purchasing power across the years you selected. Reset clears the fields.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/inflation-calculator">
@@ -11,6 +27,8 @@ const description = "Compare purchasing power across years using U.S. CPI data."
     <h1>{title}</h1>
     <p class="helper">Find out how prices have changed over time. Enter an amount and pick two years to see the equivalent value after inflation.</p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="inflation-form">

--- a/src/pages/calculators/loan-calculator.astro
+++ b/src/pages/calculators/loan-calculator.astro
@@ -1,9 +1,30 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Loan Calculator";
 const description = "Estimate monthly loan payments with a full principal and interest breakdown.";
+const instructions = [
+  {
+    label: "Loan amount",
+    description: "Enter the total you plan to borrow.",
+  },
+  {
+    label: "Annual interest rate (%)",
+    description: "Provide the loan's APR as a percentage.",
+  },
+  {
+    label: "Loan term (years)",
+    description: "Enter the repayment period in years.",
+  },
+  {
+    label: "Extra monthly payment",
+    description: "Optional. Add any additional amount you expect to pay each month on top of the scheduled payment.",
+  },
+];
+const instructionsFooter =
+  "Select Calculate payment to see the monthly amount, total interest, and payoff schedule. Reset clears the form.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/loan-calculator">
@@ -11,6 +32,8 @@ const description = "Estimate monthly loan payments with a full principal and in
     <h1>{title}</h1>
     <p class="helper">Plug in a loan amount, interest rate, and term to see your monthly payment plus how much goes toward principal versus interest.</p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="loan-form">

--- a/src/pages/calculators/macros-calculator.astro
+++ b/src/pages/calculators/macros-calculator.astro
@@ -1,10 +1,35 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Macros Calculator";
 const description =
   "Convert a calorie target into daily protein, carbohydrate, and fat goals tailored to your training focus.";
+const instructions = [
+  {
+    label: "Weight units",
+    description: "Choose whether you'll enter weight in kilograms or pounds.",
+  },
+  {
+    label: "Body weight",
+    description: "Enter your current body weight using the selected units. It's used for high-protein splits.",
+  },
+  {
+    label: "Daily calories",
+    description: "Enter the calorie target you want to hit each day.",
+  },
+  {
+    label: "Macro split",
+    description: "Pick a preset distribution or choose Custom to enter your own percentages.",
+  },
+  {
+    label: "Custom percentages",
+    description: "If you select Custom, fill in the protein, carb, and fat percentages so they add up to 100%.",
+  },
+];
+const instructionsFooter =
+  "Click Break down macros to convert your calorie goal into grams of protein, carbs, and fats. Reset clears all values.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/macros-calculator">
@@ -15,6 +40,8 @@ const description =
       Use it alongside the BMR calculator to dial in your nutrition.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="macros-form">

--- a/src/pages/calculators/meal-planner.astro
+++ b/src/pages/calculators/meal-planner.astro
@@ -1,9 +1,34 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Meal Planner & Portion Calculator";
 const description = "Scale recipes and grocery lists for any gathering based on adult and kid headcount.";
+const instructions = [
+  {
+    label: "Adults",
+    description: "Enter how many adults you're feeding.",
+  },
+  {
+    label: "Children",
+    description: "Enter the number of kids (they count as 0.6 of an adult portion).",
+  },
+  {
+    label: "Meal style",
+    description: "Pick light, standard, or hearty service to adjust portion sizes.",
+  },
+  {
+    label: "Leftover buffer (%)",
+    description: "Add a cushion for second helpings or meal prep. We'll increase quantities by this percentage.",
+  },
+  {
+    label: "Include courses",
+    description: "Check the dishes you plan to serve—protein, starch, vegetables, salad, dessert, and drinks—to include them in the totals.",
+  },
+];
+const instructionsFooter =
+  "Press Calculate portions to get suggested quantities for each course and a shopping list. Reset returns to the default headcount.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/meal-planner">
@@ -14,6 +39,8 @@ const description = "Scale recipes and grocery lists for any gathering based on 
       vegetables, dessert, and drinks—plus the total shopping list with leftovers included.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="meal-form" autocomplete="off">

--- a/src/pages/calculators/mortgage-calculator.astro
+++ b/src/pages/calculators/mortgage-calculator.astro
@@ -1,9 +1,50 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Mortgage Calculator";
 const description = "Plan a home purchase with affordability guidance and an amortization schedule.";
+const instructions = [
+  {
+    label: "Home price",
+    description: "Enter the purchase price of the property.",
+  },
+  {
+    label: "Down payment (%)",
+    description: "Specify how much of the price you'll pay upfront as a percentage.",
+  },
+  {
+    label: "Interest rate (%)",
+    description: "Provide the mortgage interest rate (APR).",
+  },
+  {
+    label: "Loan term (years)",
+    description: "Enter the repayment period for the loan in years.",
+  },
+  {
+    label: "Property tax rate",
+    description: "Input your annual property tax rate as a percent of home value.",
+  },
+  {
+    label: "Home insurance",
+    description: "Estimate your yearly homeowners insurance premium.",
+  },
+  {
+    label: "HOA dues",
+    description: "Enter any monthly homeowners association fees, or leave zero if none.",
+  },
+  {
+    label: "Household income",
+    description: "Optional. Add your gross annual income to run an affordability check.",
+  },
+  {
+    label: "Monthly debt payments",
+    description: "Optional. Enter existing monthly debts (loans, credit cards) to refine the affordability guideline.",
+  },
+];
+const instructionsFooter =
+  "Hit Run mortgage math to calculate payments, total interest, and affordability metrics. Reset clears the form.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/mortgage-calculator">
@@ -11,6 +52,8 @@ const description = "Plan a home purchase with affordability guidance and an amo
     <h1>{title}</h1>
     <p class="helper">Estimate your monthly mortgage payment, check how much home you can afford, and review a year-by-year payoff schedule.</p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="mortgage-form">

--- a/src/pages/calculators/overtime-pay-calculator.astro
+++ b/src/pages/calculators/overtime-pay-calculator.astro
@@ -1,9 +1,38 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Overtime Pay Calculator";
 const description = "Estimate total pay with overtime premiums, double time, and flat shift bonuses.";
+const instructions = [
+  {
+    label: "Base hourly rate",
+    description: "Enter your standard hourly wage.",
+  },
+  {
+    label: "Regular hours",
+    description: "Input the hours paid at the base rate this pay period.",
+  },
+  {
+    label: "Overtime hours",
+    description: "Enter hours paid at the overtime multiplier (commonly any time over 40 hours).",
+  },
+  {
+    label: "Overtime multiplier",
+    description: "Adjust the premium rate if your overtime is not 1.5×.",
+  },
+  {
+    label: "Double-time hours",
+    description: "Include any hours paid at 2× the base rate.",
+  },
+  {
+    label: "Flat bonus or stipend",
+    description: "Add any extra flat pay tied to the shift.",
+  },
+];
+const instructionsFooter =
+  "Choose Calculate pay to total your base, overtime, and double-time earnings plus bonuses. Reset clears the form.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/overtime-pay-calculator">
@@ -14,6 +43,8 @@ const description = "Estimate total pay with overtime premiums, double time, and
       calculator handles common 1.5× overtime and optional 2× double time.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="overtime-form">

--- a/src/pages/calculators/password-generator.astro
+++ b/src/pages/calculators/password-generator.astro
@@ -1,9 +1,25 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Password Generator";
 const description = "Create strong passwords with adjustable length and character options.";
+const instructions = [
+  {
+    label: "Password length",
+    description: "Choose how many characters long the password should be (4–64).",
+  },
+  {
+    label: "Character sets",
+    description: "Check the boxes for lowercase, uppercase, numbers, and symbols you want to include.",
+  },
+  {
+    label: "Avoid similar characters",
+    description: "Enable this to remove look-alike characters like O/0 and l/1 from the generated password.",
+  },
+];
+const instructionsFooter = "Click Generate password to produce a new secure string. Reset restores the default options.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/password-generator">
@@ -14,6 +30,8 @@ const description = "Create strong passwords with adjustable length and characte
       need and copy them with one click.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="password-form">

--- a/src/pages/calculators/paycheck-tax-calculator.astro
+++ b/src/pages/calculators/paycheck-tax-calculator.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Paycheck Tax Calculator";
 const description = "Estimate take-home pay by state with federal, payroll, and local tax assumptions.";
@@ -58,6 +59,34 @@ const states = [
   { code: "WI", name: "Wisconsin" },
   { code: "WY", name: "Wyoming" },
 ];
+const instructions = [
+  {
+    label: "Annual gross pay",
+    description: "Enter your salary or total wages before taxes.",
+  },
+  {
+    label: "Pay frequency",
+    description: "Choose how often you get paid so the calculator divides your annual income correctly.",
+  },
+  {
+    label: "Filing status",
+    description: "Select your federal filing status for the correct standard deduction and brackets.",
+  },
+  {
+    label: "State",
+    description: "Pick where you work or pay state income tax to apply the appropriate tax rate.",
+  },
+  {
+    label: "Pre-tax deductions per paycheck",
+    description: "Optional. Enter amounts withheld before taxes (401k, HSA, commuter benefits).",
+  },
+  {
+    label: "Post-tax deductions per paycheck",
+    description: "Optional. Add insurance premiums or other after-tax deductions taken from each paycheck.",
+  },
+];
+const instructionsFooter =
+  "Press Estimate take-home to calculate federal, payroll, and state withholdings along with net pay. Reset clears the fields.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/paycheck-tax-calculator">
@@ -68,6 +97,8 @@ const states = [
       Enter per-paycheck deductions to tailor the net pay estimate to your situation.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="paycheck-form">

--- a/src/pages/calculators/pdf-to-word.astro
+++ b/src/pages/calculators/pdf-to-word.astro
@@ -1,9 +1,18 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "PDF to Word / Text Extractor";
 const description = "Pull plain text from a PDF and download it as a Word or TXT document.";
+const instructions = [
+  {
+    label: "Choose a PDF",
+    description: "Upload a PDF from your device. Text-based files extract best; scanned images may return limited text.",
+  },
+];
+const instructionsFooter =
+  "After processing, use Download as Word, Download TXT, or Copy text to export the results. Clear resets the form.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/pdf-to-word">
@@ -14,6 +23,8 @@ const description = "Pull plain text from a PDF and download it as a Word or TXT
       the text or download a simple Word document.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="pdf-form">

--- a/src/pages/calculators/pet-age-converter.astro
+++ b/src/pages/calculators/pet-age-converter.astro
@@ -1,9 +1,26 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Pet Age Converter";
 const description = "Convert a dog's or cat's human-age lifespan into pet years with an optional birth-month helper.";
+const instructions = [
+  {
+    label: "Species",
+    description: "Choose dog or cat to apply the correct growth curve.",
+  },
+  {
+    label: "Human years lived",
+    description: "Enter the pet's age in human years. Decimals are OK for partial years.",
+  },
+  {
+    label: "Birth month & year",
+    description: "Optional. Select the birth month to auto-calculate human years based on today's date.",
+  },
+];
+const instructionsFooter =
+  "Press Convert to pet years to estimate the pet-equivalent age and view the reference chart. Reset clears the inputs.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/pet-age-converter">
@@ -14,6 +31,8 @@ const description = "Convert a dog's or cat's human-age lifespan into pet years 
       we'll translate that into pet years using veterinary growth curves.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="pet-age-form">

--- a/src/pages/calculators/qr-code-generator.astro
+++ b/src/pages/calculators/qr-code-generator.astro
@@ -1,9 +1,30 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "QR Code Generator";
 const description = "Turn any text or URL into a ready-to-download QR code image.";
+const instructions = [
+  {
+    label: "Text or link",
+    description: "Paste the content you want encoded—URLs, contact info, Wi-Fi credentials, or plain text.",
+  },
+  {
+    label: "Image size (pixels)",
+    description: "Set the width and height of the output PNG.",
+  },
+  {
+    label: "Error correction",
+    description: "Choose how much redundancy the QR code should include (higher percentages resist damage but add density).",
+  },
+  {
+    label: "Quiet zone",
+    description: "Adjust the blank border around the QR code measured in modules.",
+  },
+];
+const instructionsFooter =
+  "Select Generate QR code to render the image, then download or copy it from the preview. Reset clears all fields.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/qr-code-generator">
@@ -14,6 +35,8 @@ const description = "Turn any text or URL into a ready-to-download QR code image
       level before downloading.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="qr-form">

--- a/src/pages/calculators/salary-to-hourly.astro
+++ b/src/pages/calculators/salary-to-hourly.astro
@@ -1,9 +1,30 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Salary ↔ Hourly Converter";
 const description = "Quickly convert annual pay to hourly wages (and back again).";
+const instructions = [
+  {
+    label: "Annual salary",
+    description: "Enter your yearly pay if you want to convert it to an hourly rate.",
+  },
+  {
+    label: "Hourly rate",
+    description: "Enter your hourly wage if you want to convert it to an annual salary.",
+  },
+  {
+    label: "Hours per week",
+    description: "Provide the number of paid hours you work each week.",
+  },
+  {
+    label: "Paid weeks per year",
+    description: "Enter how many weeks you are paid in a year (exclude unpaid time off).",
+  },
+];
+const instructionsFooter =
+  "Use the Annual → Hourly or Hourly → Annual buttons to run the conversion based on the fields you've filled. Reset clears the form.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/salary-to-hourly">
@@ -11,6 +32,8 @@ const description = "Quickly convert annual pay to hourly wages (and back again)
     <h1>{title}</h1>
     <p class="helper">Enter either your yearly salary or hourly wage along with your typical schedule to see the equivalent pay.</p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="salary-form">

--- a/src/pages/calculators/savings-goal-calculator.astro
+++ b/src/pages/calculators/savings-goal-calculator.astro
@@ -1,9 +1,30 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Savings Goal Calculator";
 const description = "Figure out the monthly contributions needed to hit a future target.";
+const instructions = [
+  {
+    label: "Goal amount",
+    description: "Enter how much money you want to accumulate.",
+  },
+  {
+    label: "Current savings",
+    description: "Add what you already have saved toward this goal (optional).",
+  },
+  {
+    label: "Timeframe (years)",
+    description: "Provide how many years you have to reach the goal. Use decimals for partial years.",
+  },
+  {
+    label: "Expected annual return (%)",
+    description: "Optional. Enter an estimated annual rate of return if funds are invested. Use 0% for a no-interest plan.",
+  },
+];
+const instructionsFooter =
+  "Select Calculate monthly savings to see the deposit amount needed each month plus totals saved and interest earned. Reset clears the fields.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/savings-goal-calculator">
@@ -11,6 +32,8 @@ const description = "Figure out the monthly contributions needed to hit a future
     <h1>{title}</h1>
     <p class="helper">Set a target amount and timeline. We'll tell you how much to save each month, factoring in optional investment growth.</p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="savings-form">

--- a/src/pages/calculators/savings-vs-investing-comparison.astro
+++ b/src/pages/calculators/savings-vs-investing-comparison.astro
@@ -1,9 +1,38 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Savings vs Investing Comparison";
 const description = "Compare projected growth of cash kept in a bank account versus invested in the market.";
+const instructions = [
+  {
+    label: "Starting balance",
+    description: "Enter the amount of money you have today.",
+  },
+  {
+    label: "Monthly contribution",
+    description: "Add how much you plan to deposit each month (optional).",
+  },
+  {
+    label: "Years to grow",
+    description: "Set the time horizon for the comparison.",
+  },
+  {
+    label: "Bank APY (%)",
+    description: "Enter the annual percentage yield for a savings account or cash alternative.",
+  },
+  {
+    label: "Expected investment return (%)",
+    description: "Provide the average annual return you expect from investing.",
+  },
+  {
+    label: "Investment fees (%)",
+    description: "Enter yearly investment costs (expense ratios, advisory fees). We'll subtract them from returns.",
+  },
+];
+const instructionsFooter =
+  "Press Compare growth to chart both balances over time and see the difference in ending value. Reset clears the inputs.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/savings-vs-investing-comparison">
@@ -14,6 +43,8 @@ const description = "Compare projected growth of cash kept in a bank account ver
       monthly contributions, and time horizon to see how the gap changes.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="compare-form">

--- a/src/pages/calculators/shoe-size-converter.astro
+++ b/src/pages/calculators/shoe-size-converter.astro
@@ -1,9 +1,26 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Shoe Size Converter";
 const description = "Match men's and women's shoe sizes across US, UK, and EU charts.";
+const instructions = [
+  {
+    label: "Sizing chart",
+    description: "Select women's or men's sizing to load the appropriate chart.",
+  },
+  {
+    label: "I know my size in",
+    description: "Choose the sizing system you already have—US, UK, or EU.",
+  },
+  {
+    label: "Size",
+    description: "Pick your known size. We'll display the matching sizes in the other systems.",
+  },
+];
+const instructionsFooter =
+  "Press Convert to see the equivalents and Reset to start over.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/shoe-size-converter">
@@ -14,6 +31,8 @@ const description = "Match men's and women's shoe sizes across US, UK, and EU ch
       regions.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="shoe-form">

--- a/src/pages/calculators/speed-converter.astro
+++ b/src/pages/calculators/speed-converter.astro
@@ -1,9 +1,21 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Speed Converter";
 const description = "Quickly swap between miles per hour and kilometers per hour.";
+const instructions = [
+  {
+    label: "Conversion direction",
+    description: "Select whether you are converting mph to km/h or km/h to mph.",
+  },
+  {
+    label: "Value",
+    description: "Enter the speed you want to convert. Use decimals for more precision.",
+  },
+];
+const instructionsFooter = "Press Convert to get the equivalent speed. Reset clears the form.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/speed-converter">
@@ -13,6 +25,8 @@ const description = "Quickly swap between miles per hour and kilometers per hour
       Road trip abroad? Convert mph and km/h instantly using the exact 1 mile = 1.609344 kilometers conversion factor.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="speed-form">

--- a/src/pages/calculators/text-case-converter.astro
+++ b/src/pages/calculators/text-case-converter.astro
@@ -1,9 +1,18 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Text Case Converter";
 const description = "Switch text between uppercase, lowercase, and title case instantly.";
+const instructions = [
+  {
+    label: "Your text",
+    description: "Paste or type the content you want to convert. We'll create a transformed copy while leaving your original text intact.",
+  },
+];
+const instructionsFooter =
+  "Use the Uppercase, Lowercase, or Title Case buttons to generate the result below. Clear resets the input area.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/text-case-converter">
@@ -14,6 +23,8 @@ const description = "Switch text between uppercase, lowercase, and title case in
       you can drop the result right back into your document.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="case-form">

--- a/src/pages/calculators/time-zone-converter.astro
+++ b/src/pages/calculators/time-zone-converter.astro
@@ -1,9 +1,26 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Time Zone Converter";
 const description = "Compare the same moment across world cities with automatic daylight-saving handling.";
+const instructions = [
+  {
+    label: "Date & time",
+    description: "Enter the date and time in your origin city.",
+  },
+  {
+    label: "Origin city",
+    description: "Choose the city and time zone you are starting from.",
+  },
+  {
+    label: "Select cities to compare",
+    description: "Pick one or more destination cities to see their corresponding local times.",
+  },
+];
+const instructionsFooter =
+  "Click Compare times to list each city's local time and offset from the origin. Reset clears your selections.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/time-zone-converter">
@@ -14,6 +31,8 @@ const description = "Compare the same moment across world cities with automatic 
       each city and how far ahead or behind it is.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="time-form">

--- a/src/pages/calculators/tip-calculator.astro
+++ b/src/pages/calculators/tip-calculator.astro
@@ -1,9 +1,30 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Tip Calculator";
 const description = "Split restaurant bills with tip suggestions and per-person totals.";
+const instructions = [
+  {
+    label: "Bill amount",
+    description: "Enter the pre-tip total from the check.",
+  },
+  {
+    label: "Tip percentage",
+    description: "Choose a suggested tip or pick Custom to enter your own percentage.",
+  },
+  {
+    label: "Custom tip (%)",
+    description: "Appears when Custom is selected. Enter the tip percentage you want to apply.",
+  },
+  {
+    label: "People splitting",
+    description: "Enter how many people are splitting the bill to see per-person totals.",
+  },
+];
+const instructionsFooter =
+  "Press Calculate tip to see the tip amount, total bill, and per-person share. Reset clears the form.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/tip-calculator">
@@ -11,6 +32,8 @@ const description = "Split restaurant bills with tip suggestions and per-person 
     <h1>{title}</h1>
     <p class="helper">Pick a tip percentage, enter the bill, and optionally split the total between friends. We'll show tip amounts instantly.</p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="tip-form">

--- a/src/pages/calculators/unit-converter.astro
+++ b/src/pages/calculators/unit-converter.astro
@@ -1,9 +1,30 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Unit Converter";
 const description = "Convert between length, weight, temperature, and volume units with precise rounding.";
+const instructions = [
+  {
+    label: "Measurement type",
+    description: "Choose the category—length, weight, temperature, or volume—to load matching units.",
+  },
+  {
+    label: "Amount",
+    description: "Enter the value you want to convert.",
+  },
+  {
+    label: "From unit",
+    description: "Select the unit you currently have.",
+  },
+  {
+    label: "To unit",
+    description: "Pick the unit you want to convert into.",
+  },
+];
+const instructionsFooter =
+  "Press Convert to run the calculation or adjust fields to update the result live. Reset returns to the defaults.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/unit-converter">
@@ -14,6 +35,8 @@ const description = "Convert between length, weight, temperature, and volume uni
       exact conversion factors.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="unit-form">

--- a/src/pages/calculators/water-intake-calculator.astro
+++ b/src/pages/calculators/water-intake-calculator.astro
@@ -1,9 +1,30 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Daily Water Intake Calculator";
 const description = "Estimate how much water to drink each day based on weight, exercise, and climate.";
+const instructions = [
+  {
+    label: "Units",
+    description: "Choose whether you'll enter weight in kilograms or pounds.",
+  },
+  {
+    label: "Weight",
+    description: "Enter your body weight using the selected units.",
+  },
+  {
+    label: "Active minutes",
+    description: "Add how many minutes of exercise you typically do per day.",
+  },
+  {
+    label: "Climate",
+    description: "Pick the environment you spend most of your day in so we can adjust for heat and humidity.",
+  },
+];
+const instructionsFooter =
+  "Click Calculate water target to get your suggested daily intake in liters, ounces, and cups. Reset clears the form.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/water-intake-calculator">
@@ -14,6 +35,8 @@ const description = "Estimate how much water to drink each day based on weight, 
       exercise into a reasonable water target.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="water-form">

--- a/src/pages/calculators/word-counter.astro
+++ b/src/pages/calculators/word-counter.astro
@@ -1,9 +1,26 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AdSlot from "@/components/AdSlot.astro";
+import InstructionList from "@/components/InstructionList.astro";
 
 const title = "Word & Character Counter";
 const description = "Count words, characters, sentences, and estimate reading time for any text.";
+const instructions = [
+  {
+    label: "Your text",
+    description: "Paste or type the content you want to analyze.",
+  },
+  {
+    label: "Word target",
+    description: "Optional. Enter a goal word count to track progress toward it.",
+  },
+  {
+    label: "Reading speed (words/min)",
+    description: "Adjust the words-per-minute rate used to estimate reading time.",
+  },
+];
+const instructionsFooter =
+  "Statistics update live as you type. Use Copy text to grab your writing or Clear to start over.";
 ---
 
 <BaseLayout {title} {description} pathname="/calculators/word-counter">
@@ -14,6 +31,8 @@ const description = "Count words, characters, sentences, and estimate reading ti
       reading time estimate. Set a word target to track your progress.
     </p>
   </section>
+
+  <InstructionList items={instructions} footer={instructionsFooter} />
 
   <section class="card" style="margin-top:18px;">
     <form id="word-counter-form">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -394,6 +394,47 @@ a:hover {
   color: var(--muted);
 }
 
+.card.info-card {
+  cursor: default;
+}
+
+.card.info-card:hover {
+  transform: none;
+  border-color: var(--border);
+  box-shadow: var(--shadow);
+}
+
+.instructions-card {
+  margin-top: 18px;
+}
+
+.instructions-card h2 {
+  margin: 0 0 10px;
+  font-size: 18px;
+}
+
+.instructions-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.instructions-list li {
+  display: grid;
+  gap: 4px;
+}
+
+.instructions-term {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.instructions-detail {
+  color: var(--muted);
+}
+
 .btn {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add an InstructionList component and supporting styles to render per-field instructions
- wire the new component into each calculator page with tailored guidance on what to enter

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9ab45f9188323a5a30f288bc77f85