### PR TITLE
Add AdSense script to layout head

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -21,6 +21,11 @@ const url = new URL(pathname, Astro.site ?? "http://localhost:4321");
     <script is:inline>
       document.documentElement.classList.add("js");
     </script>
+    <script
+      async
+      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7272853160794667"
+      crossorigin="anonymous"
+    ></script>
 
     <!-- Social -->
     <meta property="og:title" content={title} />


### PR DESCRIPTION
## Summary
- add the Google AdSense loader script inside the shared layout head so it appears on every page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9bb9393ec8323b928e41c9bffc7e6