### PR TITLE
Make instructions sections collapsible

### DIFF
--- a/src/components/InstructionList.astro
+++ b/src/components/InstructionList.astro
@@ -4,15 +4,19 @@ const { heading = "How to use this tool", items = [], footer } = Astro.props;
 
 {items.length > 0 && (
   <section class="card info-card instructions-card" aria-label="Input instructions">
-    <h2>{heading}</h2>
-    <ul class="instructions-list">
-      {items.map((item) => (
-        <li>
-          <span class="instructions-term">{item.label}</span>
-          <span class="instructions-detail">{item.description}</span>
-        </li>
-      ))}
-    </ul>
-    {footer && <p class="helper">{footer}</p>}
+    <details class="instructions-details">
+      <summary class="instructions-summary">{heading}</summary>
+      <div class="instructions-content">
+        <ul class="instructions-list">
+          {items.map((item) => (
+            <li>
+              <span class="instructions-term">{item.label}</span>
+              <span class="instructions-detail">{item.description}</span>
+            </li>
+          ))}
+        </ul>
+        {footer && <p class="helper">{footer}</p>}
+      </div>
+    </details>
   </section>
 )}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -408,9 +408,49 @@ a:hover {
   margin-top: 18px;
 }
 
-.instructions-card h2 {
-  margin: 0 0 10px;
+.instructions-details {
+  margin: 0;
+}
+
+.instructions-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin: 0;
+  cursor: pointer;
+  list-style: none;
   font-size: 18px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.instructions-summary::-webkit-details-marker {
+  display: none;
+}
+
+.instructions-summary::after {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+}
+
+.instructions-details[open] .instructions-summary::after {
+  transform: rotate(-135deg);
+}
+
+.instructions-summary:focus-visible {
+  outline: 2px solid rgba(78, 140, 255, 0.5);
+  outline-offset: 4px;
+}
+
+.instructions-content {
+  margin-top: 14px;
 }
 
 .instructions-list {


### PR DESCRIPTION
## Summary
- convert the shared InstructionList component into a collapsible details element so directions are hidden by default
- add styling for the new summary toggle so it matches the existing card presentation and shows an expand indicator

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9bd96aaf48323bb58ea4244ceedf2