### PR TITLE
Add interactive calculator search to home page

### DIFF
--- a/src/lib/calculatorData.ts
+++ b/src/lib/calculatorData.ts
@@ -3,6 +3,7 @@ export interface CalculatorInfo {
   name: string;
   navLabel: string;
   description: string;
+  keywords: string[];
 }
 
 export interface CalculatorCategory {
@@ -22,6 +23,13 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Days From Date",
         description:
           "Find how many days are between any two dates—or from today.",
+        keywords: [
+          "days between",
+          "day counter",
+          "date difference",
+          "countdown",
+          "days until",
+        ],
       },
       {
         href: "/calculators/age-calculator",
@@ -29,12 +37,25 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Age",
         description:
           "Enter a birthdate to see your age in years, months, and days.",
+        keywords: [
+          "how old",
+          "birth date",
+          "age in days",
+          "birthday",
+          "age finder",
+        ],
       },
       {
         href: "/calculators/days-until-birthday",
         name: "Days Until Your Birthday",
         navLabel: "Birthday",
         description: "Countdown with leap-year handling for Feb 29 birthdays.",
+        keywords: [
+          "birthday countdown",
+          "birthday timer",
+          "days until birthday",
+          "next birthday",
+        ],
       },
       {
         href: "/calculators/anniversary-countdown",
@@ -42,12 +63,25 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Anniversary",
         description:
           "Preview the next few anniversaries for any meaningful date.",
+        keywords: [
+          "days until anniversary",
+          "relationship milestone",
+          "marriage countdown",
+          "anniversary date",
+        ],
       },
       {
         href: "/calculators/holiday-countdown",
         name: "Holiday Countdown (US)",
         navLabel: "Holidays",
         description: "See days remaining until major U.S. holidays.",
+        keywords: [
+          "christmas countdown",
+          "holiday timer",
+          "days until holiday",
+          "us holidays",
+          "thanksgiving countdown",
+        ],
       },
       {
         href: "/calculators/flight-time-calculator",
@@ -55,6 +89,13 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Flight Time",
         description:
           "Estimate nonstop duration, arrival time, and time zone shifts between major airports.",
+        keywords: [
+          "flight duration",
+          "travel time",
+          "airport finder",
+          "airline route",
+          "flight distance",
+        ],
       },
     ],
   },
@@ -68,6 +109,13 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Paycheck",
         description:
           "Estimate take-home pay by state with federal, payroll, and state taxes.",
+        keywords: [
+          "take home pay",
+          "paycheck after tax",
+          "net pay",
+          "salary calculator",
+          "pay stub",
+        ],
       },
       {
         href: "/calculators/overtime-pay-calculator",
@@ -75,6 +123,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Overtime",
         description:
           "See total pay when overtime and double-time hours stack onto your shift.",
+        keywords: [
+          "time and a half",
+          "double time",
+          "overtime wages",
+          "extra hours",
+        ],
       },
       {
         href: "/calculators/freelancer-hourly-rate-calculator",
@@ -82,6 +136,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Freelance",
         description:
           "Back into a sustainable freelance rate using income goals and billable hours.",
+        keywords: [
+          "freelance pricing",
+          "contract rate",
+          "billable hours",
+          "hourly quote",
+        ],
       },
       {
         href: "/calculators/salary-to-hourly",
@@ -89,6 +149,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Salary",
         description:
           "Convert yearly pay to hourly wages (and vice versa) with your schedule.",
+        keywords: [
+          "salary to hourly",
+          "hourly to salary",
+          "pay converter",
+          "annual pay",
+        ],
       },
       {
         href: "/calculators/loan-calculator",
@@ -96,6 +162,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Loan",
         description:
           "Estimate payments and see principal versus interest by year.",
+        keywords: [
+          "monthly payment",
+          "loan payment",
+          "amortization",
+          "interest calculator",
+        ],
       },
       {
         href: "/calculators/car-loan-affordability-calculator",
@@ -103,6 +175,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Car Budget",
         description:
           "Find the maximum vehicle price your income can comfortably support.",
+        keywords: [
+          "car budget",
+          "car payment",
+          "auto loan",
+          "how much car",
+        ],
       },
       {
         href: "/calculators/mortgage-calculator",
@@ -110,6 +188,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Mortgage",
         description:
           "Check affordability, monthly costs, and an amortization schedule.",
+        keywords: [
+          "mortgage payment",
+          "home loan",
+          "principal and interest",
+          "mortgage estimate",
+        ],
       },
       {
         href: "/calculators/debt-payoff-calculator",
@@ -117,6 +201,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Debt",
         description:
           "Compare snowball and avalanche payoff timelines across all your debts.",
+        keywords: [
+          "debt snowball",
+          "debt avalanche",
+          "pay off debt",
+          "debt planner",
+        ],
       },
       {
         href: "/calculators/credit-card-interest-calculator",
@@ -124,6 +214,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Card Interest",
         description:
           "Project interest charges while carrying a balance and test extra payments.",
+        keywords: [
+          "credit card apr",
+          "interest charges",
+          "carry balance",
+          "credit payoff",
+        ],
       },
       {
         href: "/calculators/compound-interest-calculator",
@@ -131,6 +227,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Invest",
         description:
           "Model investment growth with recurring deposits and raises.",
+        keywords: [
+          "investment growth",
+          "interest growth",
+          "future value",
+          "savings calculator",
+        ],
       },
       {
         href: "/calculators/savings-goal-calculator",
@@ -138,6 +240,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Savings",
         description:
           "See the monthly deposit needed to reach a target with growth.",
+        keywords: [
+          "monthly savings",
+          "target savings",
+          "goal planner",
+          "savings plan",
+        ],
       },
       {
         href: "/calculators/savings-vs-investing-comparison",
@@ -145,6 +253,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Save vs Invest",
         description:
           "Compare bank interest against market returns using the same contributions.",
+        keywords: [
+          "investing vs saving",
+          "bank vs market",
+          "compare returns",
+          "investment comparison",
+        ],
       },
       {
         href: "/calculators/currency-converter",
@@ -152,6 +266,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Currency",
         description:
           "Convert between 30+ currencies with live-rate fallback support.",
+        keywords: [
+          "exchange rate",
+          "forex",
+          "currency exchange",
+          "convert money",
+        ],
       },
       {
         href: "/calculators/inflation-calculator",
@@ -159,6 +279,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Inflation",
         description:
           "Compare the buying power of money across different years.",
+        keywords: [
+          "cpi",
+          "cost of living",
+          "inflation rate",
+          "value of money",
+        ],
       },
       {
         href: "/calculators/tip-calculator",
@@ -166,6 +292,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Tip",
         description:
           "Quickly find tip amounts and per-person totals for the table.",
+        keywords: [
+          "split bill",
+          "restaurant tip",
+          "gratuity",
+          "tip amount",
+        ],
       },
       {
         href: "/calculators/event-budget-calculator",
@@ -173,6 +305,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Event Budget",
         description:
           "Forecast venue, catering, staffing, and contingency costs with per-guest totals for any event.",
+        keywords: [
+          "wedding budget",
+          "party budget",
+          "event planning",
+          "cost per guest",
+        ],
       },
     ],
   },
@@ -186,6 +324,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Units",
         description:
           "Switch between length, weight, temperature, and volume measurements with precise factors.",
+        keywords: [
+          "measurement converter",
+          "unit conversion",
+          "metric to imperial",
+          "length weight temperature",
+        ],
       },
       {
         href: "/calculators/time-zone-converter",
@@ -193,6 +337,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Time Zones",
         description:
           "Enter a city and instantly compare the time across world capitals—DST aware.",
+        keywords: [
+          "world clock",
+          "time difference",
+          "timezone",
+          "city time",
+        ],
       },
       {
         href: "/calculators/cooking-measurement-converter",
@@ -200,6 +350,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Cooking",
         description:
           "Translate cups, grams, ounces, and spoons with a water-based kitchen reference.",
+        keywords: [
+          "baking conversion",
+          "cooking measurements",
+          "cups to grams",
+          "kitchen converter",
+        ],
       },
       {
         href: "/calculators/fuel-economy-converter",
@@ -207,6 +363,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Fuel",
         description:
           "Swap between MPG and liters per 100 km when comparing vehicle efficiency.",
+        keywords: [
+          "mpg to l/100km",
+          "gas mileage",
+          "fuel efficiency",
+          "km per liter",
+        ],
       },
       {
         href: "/calculators/speed-converter",
@@ -214,6 +376,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Speed",
         description:
           "Convert driving speeds between miles per hour and kilometers per hour.",
+        keywords: [
+          "mph to kph",
+          "speed conversion",
+          "kilometers per hour",
+          "miles per hour",
+        ],
       },
       {
         href: "/calculators/shoe-size-converter",
@@ -221,6 +389,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Shoes",
         description:
           "Match US, UK, and EU shoe sizes for men's and women's charts side by side.",
+        keywords: [
+          "us to eu shoes",
+          "shoe size chart",
+          "uk shoe size",
+          "foot size",
+        ],
       },
       {
         href: "/calculators/clothing-size-converter",
@@ -228,6 +402,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Clothing",
         description:
           "Find approximate international equivalents for common men's and women's apparel sizes.",
+        keywords: [
+          "size chart",
+          "us to eu clothing",
+          "international sizes",
+          "clothing conversion",
+        ],
       },
       {
         href: "/calculators/pet-age-converter",
@@ -235,6 +415,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Pet Age",
         description:
           "Translate cat and dog ages into human years (and back) with growth-stage context.",
+        keywords: [
+          "dog years",
+          "cat years",
+          "pet age chart",
+          "human years",
+        ],
       },
     ],
   },
@@ -247,6 +433,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         name: "BMI Calculator",
         navLabel: "BMI",
         description: "Check your body mass index and see a healthy weight range for your height.",
+        keywords: [
+          "body mass index",
+          "weight range",
+          "bmi chart",
+          "healthy weight",
+        ],
       },
       {
         href: "/calculators/bmr-calorie-calculator",
@@ -254,6 +446,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Calories",
         description:
           "Estimate daily calories for maintenance, weight loss, or muscle gain using the Mifflin-St Jeor equation.",
+        keywords: [
+          "calorie calculator",
+          "maintenance calories",
+          "bmr",
+          "metabolism",
+        ],
       },
       {
         href: "/calculators/body-fat-estimator",
@@ -261,12 +459,24 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Body Fat",
         description:
           "Approximate body fat percentage and lean mass from tape measurements using the U.S. Navy method.",
+        keywords: [
+          "body fat percentage",
+          "navy method",
+          "tape measurements",
+          "body composition",
+        ],
       },
       {
         href: "/calculators/water-intake-calculator",
         name: "Water Intake Guide",
         navLabel: "Hydration",
         description: "Find a daily water target based on body weight, activity, and climate.",
+        keywords: [
+          "daily water",
+          "hydration calculator",
+          "water per day",
+          "drink water",
+        ],
       },
       {
         href: "/calculators/macros-calculator",
@@ -274,6 +484,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Macros",
         description:
           "Split your calorie goal into daily protein, carb, and fat targets for different training goals.",
+        keywords: [
+          "macro split",
+          "protein carbs fat",
+          "nutrition goals",
+          "macro calculator",
+        ],
       },
     ],
   },
@@ -286,24 +502,48 @@ export const calculatorCategories: CalculatorCategory[] = [
         name: "Password Generator",
         navLabel: "Password",
         description: "Build strong random passwords with custom character sets and length.",
+        keywords: [
+          "random password",
+          "secure password",
+          "password maker",
+          "strong password",
+        ],
       },
       {
         href: "/calculators/text-case-converter",
         name: "Text Case Converter",
         navLabel: "Text Case",
         description: "Flip text to upper, lower, or title case without losing your formatting.",
+        keywords: [
+          "uppercase",
+          "lowercase",
+          "title case",
+          "capitalize text",
+        ],
       },
       {
         href: "/calculators/hex-rgb-color-converter",
         name: "Hex ↔ RGB Color Converter",
         navLabel: "Color",
         description: "Translate design colors between hexadecimal and RGB with a live swatch preview.",
+        keywords: [
+          "hex to rgb",
+          "color picker",
+          "color converter",
+          "rgb to hex",
+        ],
       },
       {
         href: "/calculators/qr-code-generator",
         name: "QR Code Generator",
         navLabel: "QR Code",
         description: "Turn any text or link into a downloadable QR code with adjustable size.",
+        keywords: [
+          "make qr code",
+          "qr creator",
+          "qr download",
+          "generate qr",
+        ],
       },
       {
         href: "/calculators/word-counter",
@@ -311,6 +551,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Word Counter",
         description:
           "Track words, characters, sentences, and reading time while you draft or edit text.",
+        keywords: [
+          "word count",
+          "character count",
+          "writing stats",
+          "reading time",
+        ],
       },
       {
         href: "/calculators/pdf-to-word",
@@ -318,6 +564,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "PDF Extractor",
         description:
           "Extract plain text from PDFs in your browser and download it as a Word or TXT file.",
+        keywords: [
+          "pdf text",
+          "pdf to doc",
+          "extract pdf",
+          "pdf converter",
+        ],
       },
       {
         href: "/calculators/grade-calculator",
@@ -325,6 +577,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Grade Goal",
         description:
           "See the GPA needed in remaining credits or the final exam score required to reach your target.",
+        keywords: [
+          "final grade",
+          "gpa goal",
+          "exam score",
+          "grade needed",
+        ],
       },
       {
         href: "/calculators/meal-planner",
@@ -332,6 +590,12 @@ export const calculatorCategories: CalculatorCategory[] = [
         navLabel: "Meal Planner",
         description:
           "Scale proteins, sides, desserts, and drinks for any gathering based on adults, kids, and leftovers.",
+        keywords: [
+          "meal planning",
+          "portion calculator",
+          "party food",
+          "serving sizes",
+        ],
       },
     ],
   },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,11 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { calculatorCategories } from "@/lib/calculatorData";
+
+const totalCalculators = calculatorCategories.reduce(
+  (count, category) => count + category.calculators.length,
+  0,
+);
 ---
 
 <BaseLayout
@@ -12,19 +17,105 @@ import { calculatorCategories } from "@/lib/calculatorData";
     <p>Plan timelines, budgets, and goals in one place. All tools run instantly in your browser—no sign-up required.</p>
   </section>
 
+  <section class="search-panel" aria-labelledby="calculator-search-label">
+    <div class="search-field">
+      <label id="calculator-search-label" for="calculator-search">Search calculators</label>
+      <input
+        id="calculator-search"
+        class="search-input"
+        type="search"
+        name="calculator-search"
+        placeholder='Try searching "mortgage", "MPG", or "password"'
+        autocomplete="off"
+        spellcheck="false"
+        aria-describedby="calculator-search-hint"
+      />
+    </div>
+    <p id="calculator-search-hint" class="search-hint">
+      Filter tools by title or keywords—results update as you type.
+    </p>
+    <p id="calculator-search-status" class="search-status" role="status" aria-live="polite">
+      Showing all {totalCalculators} calculators.
+    </p>
+  </section>
+
   {calculatorCategories.map((category) => (
-    <section>
+    <section class="category-section" data-category-section data-category-id={category.id}>
       <h2 class="section-title">{category.label}</h2>
       <div class="grid">
-        {category.calculators.map((calculator) => (
-          <a class="card" href={calculator.href}>
-            <h3>{calculator.name}</h3>
-            <p>{calculator.description}</p>
-            <span class="btn">Open</span>
-          </a>
-        ))}
+        {category.calculators.map((calculator) => {
+          const searchValue = [
+            calculator.name,
+            calculator.navLabel,
+            calculator.description,
+            calculator.keywords.join(" "),
+          ]
+            .join(" ")
+            .toLowerCase();
+
+          return (
+            <a class="card" href={calculator.href} data-search={searchValue}>
+              <h3>{calculator.name}</h3>
+              <p>{calculator.description}</p>
+              <span class="btn">Open</span>
+            </a>
+          );
+        })}
       </div>
     </section>
   ))}
+
+  <script is:inline>
+    const searchInput = document.getElementById("calculator-search");
+    const status = document.getElementById("calculator-search-status");
+    const sections = Array.from(document.querySelectorAll("[data-category-section]"));
+    const cards = Array.from(document.querySelectorAll("[data-search]"));
+    const totalCount = cards.length;
+
+    const formatCount = (count) => `${count} ${count === 1 ? "calculator" : "calculators"}`;
+
+    const update = (value) => {
+      const trimmedValue = value.trim();
+      const query = trimmedValue.toLowerCase();
+      let matchCount = 0;
+
+      cards.forEach((card) => {
+        const haystack = card.dataset.search ?? "";
+        const isMatch = query === "" || haystack.includes(query);
+        card.toggleAttribute("hidden", !isMatch);
+        if (isMatch) {
+          matchCount += 1;
+        }
+      });
+
+      sections.forEach((section) => {
+        const hasVisibleCard = section.querySelector('[data-search]:not([hidden])') !== null;
+        section.toggleAttribute("hidden", query !== "" && !hasVisibleCard);
+      });
+
+      if (!status) {
+        return;
+      }
+
+      if (query === "") {
+        status.textContent = `Showing all ${formatCount(totalCount)}.`;
+      } else if (matchCount === 0) {
+        status.textContent = `No calculators match “${trimmedValue}”.`;
+      } else {
+        status.textContent = `Showing ${formatCount(matchCount)} for “${trimmedValue}”.`;
+      }
+    };
+
+    searchInput?.addEventListener("input", (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLInputElement)) {
+        return;
+      }
+
+      update(target.value);
+    });
+
+    update(searchInput?.value ?? "");
+  </script>
 </BaseLayout>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -357,6 +357,68 @@ a:hover {
   color: var(--muted);
 }
 
+.search-panel {
+  margin-top: 28px;
+  padding: 24px;
+  border-radius: 18px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.search-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.search-field label {
+  font-weight: 600;
+  letter-spacing: 0.2px;
+}
+
+.search-input {
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--panel-2);
+  color: var(--text);
+  font-size: 16px;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    background 0.15s ease;
+}
+
+.search-input:hover {
+  border-color: rgba(78, 140, 255, 0.25);
+}
+
+.search-input:focus-visible {
+  outline: none;
+  border-color: rgba(78, 140, 255, 0.45);
+  box-shadow: 0 0 0 3px rgba(78, 140, 255, 0.2);
+  background: rgba(78, 140, 255, 0.08);
+}
+
+.search-input::placeholder {
+  color: color-mix(in srgb, var(--muted) 70%, transparent);
+}
+
+.search-hint {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.search-status {
+  font-size: 14px;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--text) 85%, transparent);
+}
+
 .grid {
   display: grid;
   gap: 16px;


### PR DESCRIPTION
## Summary
- add keyword metadata for each calculator to support name/keyword matching
- add a home page search panel that filters calculators live as people type
- style the search interface to fit existing cards and show result counts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca1c6d9cc083239647472bf93637b4