### PR TITLE
Fix mobile calendar buttons for date inputs

### DIFF
--- a/public/js/date-utils.js
+++ b/public/js/date-utils.js
@@ -73,6 +73,13 @@
         pickerInput.value = parsed ? formatISODate(parsed) : "";
       };
 
+      const supportsNativeShow =
+        pickerInput && typeof pickerInput.showPicker === "function";
+
+      if (pickerInput && !supportsNativeShow) {
+        field.classList.add("native-picker-fallback");
+      }
+
       if (pickerInput) {
         syncPicker();
         pickerInput.addEventListener("change", () => {
@@ -84,7 +91,7 @@
       if (trigger && pickerInput) {
         trigger.addEventListener("click", () => {
           syncPicker();
-          if (typeof pickerInput.showPicker === "function") {
+          if (supportsNativeShow) {
             pickerInput.showPicker();
           } else {
             pickerInput.focus();

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -804,6 +804,23 @@ legend {
   width: 0;
   height: 0;
 }
+.date-input.native-picker-fallback .date-picker {
+  top: 50%;
+  right: 6px;
+  transform: translateY(-50%);
+  width: 38px;
+  height: 38px;
+  z-index: 1;
+}
+@media (pointer: coarse) {
+  .date-input.native-picker-fallback .date-trigger {
+    pointer-events: none;
+  }
+
+  .date-input.native-picker-fallback .date-picker {
+    pointer-events: auto;
+  }
+}
 .helper {
   font-size: 13px;
   color: var(--muted);


### PR DESCRIPTION
## Summary
- detect browsers without `showPicker` support and flag date fields for the native fallback
- adjust date picker styles so hidden inputs can receive taps on touch devices while keeping the button visuals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc4057736883239ee8b1a668c82939